### PR TITLE
fix(webui): make overlay buttons more responsive on smaller screens

### DIFF
--- a/komga-webui/src/views/BookReader.vue
+++ b/komga-webui/src/views/BookReader.vue
@@ -156,7 +156,7 @@
           <!--  Menu: fit buttons  -->
           <v-row justify="center">
             <v-col cols="auto">
-              <v-btn-toggle v-model="fitButtons" dense mandatory active-class="primary">
+              <v-btn-toggle v-model="fitButtons" dense mandatory active-class="primary" class="flex-column flex-md-row">
                 <v-btn @click="setFit(ImageFit.WIDTH)">
                   Fit to width
                 </v-btn>
@@ -175,7 +175,7 @@
           <!--  Menu: RTL buttons  -->
           <v-row justify="center">
             <v-col cols="auto">
-              <v-btn-toggle v-model="rtlButtons" dense mandatory active-class="primary">
+              <v-btn-toggle v-model="rtlButtons" dense mandatory active-class="primary" class="flex-column flex-md-row">
                 <v-btn @click="setRtl(false)">
                   Left to right
                 </v-btn>
@@ -190,7 +190,7 @@
           <!--  Menu: double pages buttons  -->
           <v-row justify="center">
             <v-col cols="auto">
-              <v-btn-toggle v-model="doublePagesButtons" dense mandatory active-class="primary">
+              <v-btn-toggle v-model="doublePagesButtons" dense mandatory active-class="primary" class="flex-column flex-md-row">
                 <v-btn @click="setDoublePages(false)">
                   Single page
                 </v-btn>


### PR DESCRIPTION
This changes the menu buttons in the reader overlay to change to a column when on screens smaller than the md breakpoint.
It's a useful change as the buttons are often off the screen and cannot be pressed on devices as small as phones.

![large-screen](https://user-images.githubusercontent.com/4721642/74493012-cbd8be00-4e9e-11ea-8e08-9294c80b54b1.png)

![small-screen](https://user-images.githubusercontent.com/4721642/74493002-c4191980-4e9e-11ea-831a-cd4434cd5717.png)

