### PR TITLE
refactor(webui): extract logic from BookReader to handler class

### DIFF
--- a/komga-webui/src/components/PageSpreadCarousel.vue
+++ b/komga-webui/src/components/PageSpreadCarousel.vue
@@ -1,0 +1,84 @@
+<template>
+    <v-carousel :value.sync="pageCursor"
+                :show-arrows="false"
+                :continuous="false"
+                :vertical="isVertical"
+                :reverse="flipDirection"
+                hide-delimiters
+                touchless
+                height="100%"
+                v-if="spreads.spreads.length > 0"
+    >
+      <v-carousel-item
+        class="full-height"
+        v-for="(spread, i) in spreads.spreads"
+        :key="i"
+        :transition="transition"
+        :reverse-transition="transition"
+        :eager="eagerLoad(i)"
+      >
+        <page-spread-item :spread="spread" :reader="reader"></page-spread-item>
+      </v-carousel-item>
+    </v-carousel>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import PageSpreadItem from '@/components/PageSpreadItem.vue'
+
+import { PageSpread, PageSpreads } from '@/functions/pages'
+import { Reader, ReaderSettings, readSetting } from '@/functions/reader'
+import { ReadingDirection } from '@/types/enum-books'
+
+export default Vue.extend({
+  components: { PageSpreadItem },
+  name: 'PageSpreadCarousel',
+  data: () => {
+    return {
+    }
+  },
+  props: {
+    spreads: {
+      type: [ Object as () => PageSpreads ],
+      required: true,
+    },
+    reader: {
+      type: [ Object as () => Reader ],
+      required: true,
+    },
+    pageCursor: {
+      type: [Number],
+      required: true,
+    },
+  },
+  watch: {
+    pageCursor (val) {
+      this.$emit('update:pageCursor', val)
+    },
+  },
+  methods: {
+    eagerLoad (p: number): boolean {
+      return Math.abs(this.pageCursor - p) <= 2
+    },
+  },
+  computed: {
+    readingDirection: readSetting<ReadingDirection>(ReaderSettings.READ_DIR),
+    animations: readSetting<boolean>(ReaderSettings.ANIMATIONS),
+    flipDirection (): boolean {
+      return this.readingDirection === ReadingDirection.RIGHT_TO_LEFT
+    },
+    isVertical (): boolean {
+      return this.readingDirection === ReadingDirection.VERTICAL
+    },
+    transition () {
+      return this.animations ? undefined : false
+    },
+  },
+})
+</script>
+
+<style scoped>
+  .full-height {
+    height: 100%;
+  }
+</style>

--- a/komga-webui/src/components/PageSpreadItem.vue
+++ b/komga-webui/src/components/PageSpreadItem.vue
@@ -1,0 +1,71 @@
+<template>
+  <div v-if="spread && spread.pages.length > 0" class="full-height d-flex flex-column justify-center" >
+    <div class="d-flex justify-center px-0 mx-0" :class="flipClass">
+        <img v-for="page in spread.pages"
+           :src="page.url"
+           :key="page.number"
+           :height="maxHeight"
+           :width="maxWidth"
+           :class="imgClass"
+        />
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import { PageSpread } from '@/functions/pages'
+import { Optional, Reader, ReaderSettings, readSetting } from '@/functions/reader'
+import { ImageFit, ReadingDirection } from '@/types/enum-books'
+
+export default Vue.extend({
+  name: 'PageSpreadItem',
+  props: {
+    spread: {
+      type: [Object as () => PageSpread],
+      required: true,
+    },
+    reader: {
+      type: [ Object as () => Reader ],
+      required: true,
+    },
+
+  },
+  computed: {
+    imageFit: readSetting<ImageFit>(ReaderSettings.FIT),
+    readingDirection: readSetting<ReadingDirection>(ReaderSettings.READ_DIR),
+    flipDirection (): boolean {
+      return this.readingDirection === ReadingDirection.RIGHT_TO_LEFT
+    },
+    flipClass (): object {
+      return {
+        [this.flipDirection ? 'flex-row-reverse' : 'flex-row']: true,
+      }
+    },
+    imgClass () {
+      return {
+        'imagefit_width': this.imageFit === ImageFit.WIDTH,
+      }
+    },
+    maxHeight (): Optional<number> {
+      return this.imageFit === ImageFit.HEIGHT ? this.$vuetify.breakpoint.height : undefined
+    },
+    maxWidth (): Optional<number> {
+      if (this.imageFit !== ImageFit.WIDTH) {
+        return undefined
+      }
+      return this.$vuetify.breakpoint.width / this.spread.pages.length
+    },
+  },
+
+})
+</script>
+
+<style scoped>
+  .imagefit_width {
+    height: inherit;
+  }
+  .full-height {
+    height: 100%;
+  }
+</style>

--- a/komga-webui/src/components/dialogs/EditBooksDialog.vue
+++ b/komga-webui/src/components/dialogs/EditBooksDialog.vue
@@ -204,7 +204,7 @@
                   <v-row>
                     <v-col cols="">
                       <v-select v-model="form.readingDirection"
-                                :items="readingDirections"
+                                :items="formValues.readingDirections"
                                 label="Reading Direction"
                                 clearable
                                 filled
@@ -300,7 +300,7 @@
 <script lang="ts">
 import { groupAuthorsByRole } from '@/functions/authors'
 import { authorRoles } from '@/types/author-roles'
-import { ReadingDirection } from '@/types/enum-books'
+import { READING_DIR_ITEMS, ReadingDirection } from '@/types/enum-books'
 import moment from 'moment'
 import Vue from 'vue'
 import { helpers, minValue, requiredIf } from 'vuelidate/lib/validators'
@@ -343,6 +343,9 @@ export default Vue.extend({
       authorRoles,
       authorSearch: [],
       authorSearchResults: [] as string[],
+      formValues: {
+        readingDirections: READING_DIR_ITEMS,
+      },
     }
   },
   props: {
@@ -402,14 +405,7 @@ export default Vue.extend({
     single (): boolean {
       return !Array.isArray(this.books)
     },
-    readingDirections (): any[] {
-      return Object.keys(ReadingDirection).map(x => (
-        {
-          text: this.$_.capitalize(x.replace(/_/g, ' ')),
-          value: x,
-        })
-      )
-    },
+
     authorSearchResultsFull (): string[] {
       // merge local values with server search, so that already input value is available
       const local = (this.$_.values(this.form.authors).flat()) as unknown as string[]

--- a/komga-webui/src/functions/cookies.ts
+++ b/komga-webui/src/functions/cookies.ts
@@ -1,0 +1,48 @@
+import { VueCookies } from 'vue-cookies'
+
+function loadFromCookie ($cookies: VueCookies, cookieKey: string, setter: (value: any) => void): void {
+  if ($cookies.isKey(cookieKey)) {
+    let value = $cookies.get(cookieKey)
+    setter(value)
+  }
+}
+
+export type Mapper<V> = (value: any) => V
+
+export class Cookie<V> {
+  name: string
+  value: V
+  private _savetime = Infinity
+  private $cookie: VueCookies
+
+  private mapper: Mapper<V>
+
+  constructor (name: string, value: V, mapper: Mapper<V>, $cookie: VueCookies) {
+    this.name = name
+    this.value = value
+    this.mapper = mapper
+    this.$cookie = $cookie
+  }
+
+  load () {
+    if (this.$cookie.isKey(this.name)) {
+      const v = this.$cookie.get(this.name)
+      if (v) {
+        this.value = this.mapper(v)
+      }
+    }
+  }
+
+  set (value: V, save: boolean = true) {
+    if (typeof value === 'boolean' || value) {
+      this.value = value
+      if (save) {
+        this.$cookie.set(this.name, this.value, this._savetime)
+      }
+    }
+  }
+
+  get (): V {
+    return this.value
+  }
+}

--- a/komga-webui/src/functions/forms.ts
+++ b/komga-webui/src/functions/forms.ts
@@ -1,0 +1,25 @@
+
+export interface SelectItem<V> {
+  text: string
+  value: V
+}
+
+export interface Map<V> {
+  [key: string]: V
+}
+
+export class MultiMap<V> {
+  dict: Map<V[]> = {}
+
+  add (key: string, value: V) {
+    this.dict[key] = (this.dict[key]?.concat([value])) || [value]
+  }
+
+  get (key: string): V[] {
+    return this.dict[key]
+  }
+
+  items () {
+    return Object.keys(this.dict).map((k) => ({ key: k, value: this.dict[k] }))
+  }
+}

--- a/komga-webui/src/functions/pages.ts
+++ b/komga-webui/src/functions/pages.ts
@@ -1,0 +1,104 @@
+import KomgaBooksService from '@/services/komga-books.service'
+import { bookPageUrl } from '@/functions/urls'
+import { checkWebpFeature } from '@/functions/check-webp'
+
+const SUPPORTED_MEDIA_TYPES = ['image/jpeg', 'image/png', 'image/gif']
+checkWebpFeature('lossy', (feature, isSupported) => {
+  if (isSupported) {
+    SUPPORTED_MEDIA_TYPES.push('image/webp')
+  }
+})
+const convertTo: string = 'jpeg'
+
+export interface Page {
+  url: string
+  number: number
+}
+
+export interface PageSpread {
+  pages: Page[]
+}
+
+export interface PageSpreads {
+  spreads: PageSpread[]
+  indexOf: Map<number, number>
+}
+
+function getPageUrl (bookId: string, page: PageDto): string {
+  if (!SUPPORTED_MEDIA_TYPES.includes(page.mediaType)) {
+    return bookPageUrl(bookId, page.number, convertTo)
+  } else {
+    return bookPageUrl(bookId, page.number)
+  }
+}
+
+function fromPageDtos (bookId: string, ...pageDtos: PageDto[]): PageSpread {
+  const pages = pageDtos.map((p) => ({ url: getPageUrl(bookId, p), number: p.number }))
+  return { pages: pages }
+}
+
+export abstract class PageSpreadBuilder {
+  $komgaBooks: KomgaBooksService
+
+  constructor ($komgaBooks: KomgaBooksService) {
+    this.$komgaBooks = $komgaBooks
+  }
+
+  async getSpreads (book: BookDto, pages: PageDto[]): Promise<PageSpreads> {
+    let pagesCopy = [...pages]
+    return this.build(book, pagesCopy)
+  }
+
+  protected static buildIndexMap (spreads: PageSpread[]): Map<number, number> {
+    let m = new Map<number, number>()
+    for (let i = 0; i < spreads.length; i++) {
+      const spread = spreads[i]
+      for (let page of spread.pages) {
+        m.set(page.number, i)
+      }
+    }
+    return m
+  }
+
+  protected abstract build(book: BookDto, pageDtos: PageDto[]): PageSpreads
+}
+
+export class SingleSpreadBuilder extends PageSpreadBuilder {
+  protected build (book: BookDto, pageDtos: PageDto[]): PageSpreads {
+    let spreads: PageSpread[] = pageDtos.map((p) => fromPageDtos(book.id, p))
+    return { spreads, indexOf: PageSpreadBuilder.buildIndexMap(spreads) } as PageSpreads
+  }
+}
+
+export class DoubleSpreadBuilder extends PageSpreadBuilder {
+  protected build (book: BookDto, pageDtos: PageDto[]): PageSpreads {
+    let spreads = [] as PageSpread[]
+
+    // First page
+    spreads.push(fromPageDtos(book.id, pageDtos.shift()!!))
+    // Last page
+    let last = fromPageDtos(book.id, pageDtos.pop()!!)
+
+    while (pageDtos.length > 0) {
+      if (pageDtos.length > 1) {
+        // Double up
+        spreads.push(fromPageDtos(book.id, pageDtos.shift()!!, pageDtos.shift()!!))
+      } else {
+        spreads.push(fromPageDtos(book.id, pageDtos.shift()!!))
+      }
+    }
+    spreads.push(last)
+
+    return {
+      spreads,
+      indexOf: PageSpreadBuilder.buildIndexMap(spreads),
+    }
+  }
+}
+// FIXME unused
+export class WebToonBuilder extends PageSpreadBuilder {
+  protected build (book: BookDto, pageDtos: PageDto[]): PageSpreads {
+    let spreads = [ fromPageDtos(book.id, ...pageDtos) ]
+    return { spreads, indexOf: PageSpreadBuilder.buildIndexMap(spreads) }
+  }
+}

--- a/komga-webui/src/functions/reader.ts
+++ b/komga-webui/src/functions/reader.ts
@@ -1,0 +1,158 @@
+import KomgaBooksService from '@/services/komga-books.service'
+import { ImageFit, ReadingDirection } from '@/types/enum-books'
+import { Map } from '@/functions/forms'
+import KomgaSeriesService from '@/services/komga-series.service'
+import { getBookTitleCompact } from '@/functions/book-title'
+import { Cookie, Mapper } from '@/functions/cookies'
+import { VueCookies } from 'vue-cookies'
+import { bookPageUrl } from '@/functions/urls'
+import { checkWebpFeature } from '@/functions/check-webp'
+
+type Optional<V> = V | undefined
+
+export enum ReaderSettings {
+  DOUBLE_PAGES = 'webreader.doublePages',
+  SWIPE = 'webreader.swipe',
+  FIT = 'webreader.fit',
+  READ_DIR = 'webreader.readingDirection',
+  ANIMATIONS = 'webreader.animations',
+  BG_COLOR = 'webreader.background',
+}
+
+const TRUE_MAPPER = (v: any) => v === 'true'
+const IDENTITY_MAPPER = (v: any) => v
+
+async function tryCatch<V> (f: () => Promise<V>, defaultValue: V): Promise<V> {
+  return f().catch((r) => {
+    return defaultValue
+  })
+}
+
+export class Reader {
+  $komgaBooks: KomgaBooksService
+  $komgaSeries: KomgaSeriesService
+  $cookie: VueCookies
+  readonly settings: Map<Cookie<any>> = {}
+  public siblingPrev: Optional<BookDto>
+  public siblingNext: Optional<BookDto>
+  public book: BookDto = {} as BookDto
+  public series: SeriesDto = {} as SeriesDto
+  public pages: PageDto[] = []
+  bookId: string = ''
+  loaded: boolean = false
+
+  convertTo: string = 'jpeg'
+  SUPPORTED_MEDIA_TYPES = ['image/jpeg', 'image/png', 'image/gif']
+
+  constructor ($komgaBooks: KomgaBooksService, $komgaSeries: KomgaSeriesService, $cookie: VueCookies) {
+    // services
+    this.$komgaBooks = $komgaBooks
+    this.$komgaSeries = $komgaSeries
+    this.$cookie = $cookie
+    this.defaultSettings()
+
+    checkWebpFeature('lossy', (feature, isSupported) => {
+      if (isSupported) {
+        this.SUPPORTED_MEDIA_TYPES.push('image/webp')
+      }
+    })
+  }
+
+  private addSetting<V> (name: string, defaultValue: V, mapper: Mapper<V>) {
+    this.settings[name] = new Cookie<V>(name, defaultValue, mapper, this.$cookie)
+  }
+
+  defaultSettings () {
+    this.addSetting(ReaderSettings.DOUBLE_PAGES, false, TRUE_MAPPER)
+    this.addSetting(ReaderSettings.SWIPE, true, TRUE_MAPPER)
+    this.addSetting(ReaderSettings.ANIMATIONS, true, TRUE_MAPPER)
+    this.addSetting(ReaderSettings.FIT, ImageFit.HEIGHT, IDENTITY_MAPPER)
+    this.addSetting(ReaderSettings.READ_DIR, ReadingDirection.LEFT_TO_RIGHT, IDENTITY_MAPPER)
+    this.addSetting(ReaderSettings.BG_COLOR, 'black', IDENTITY_MAPPER)
+  }
+
+  public async setup (bookId: string) {
+    const $komgaBooks = this.$komgaBooks
+    this.bookId = bookId
+    this.book = await $komgaBooks.getBook(bookId)
+    this.pages = await $komgaBooks.getBookPages(bookId)
+    this.series = await this.$komgaSeries.getOneSeries(this.book.seriesId)
+    this.siblingPrev = await tryCatch(() => $komgaBooks.getBookSiblingPrevious(bookId), undefined)
+    this.siblingNext = await tryCatch(() => $komgaBooks.getBookSiblingNext(bookId), undefined)
+    // Load all settings from cookies
+    for (let setting of Object.values(this.settings)) {
+      setting.load()
+    }
+
+    this.loaded = true
+  }
+
+  /*
+  @return true if reading direction was coerced by book metadata
+   */
+  public coerceReadingDirection (): boolean {
+    // set non-persistent reading direction if exists in metadata
+    let metadataReadingDirection = this.book.metadata.readingDirection
+    if (metadataReadingDirection) {
+      let readingDirection = this.get(ReaderSettings.READ_DIR)
+      if (readingDirection !== metadataReadingDirection) {
+        this.set(ReaderSettings.READ_DIR, metadataReadingDirection, false)
+        return true
+      }
+    }
+    return false
+  }
+
+  public pagesCount () {
+    return this.pages.length
+  }
+
+  public bookTitle () {
+    if (this.book?.metadata && this.series?.metadata) {
+      return getBookTitleCompact(this.book.metadata.title, this.series.metadata.title)
+    }
+  }
+
+  public get<V> (name: string): V {
+    let c = this.settings[name] as Cookie<V>
+    return c.get()
+  }
+
+  public set<V> (name: string, value: V, save: boolean = true) {
+    let c = this.settings[name] as Cookie<V>
+    c.set(value, save)
+  }
+
+  public getPageUrl (page: number): string {
+    if (!this.SUPPORTED_MEDIA_TYPES.includes(this.pages[page - 1].mediaType)) {
+      return bookPageUrl(this.bookId, page, this.convertTo)
+    } else {
+      return bookPageUrl(this.bookId, page)
+    }
+  }
+
+  public determinePage (page: number): number {
+    if (page >= 1 && page <= this.pagesCount()) {
+      return page
+    } else if (!this.isCompleted()) {
+      return this.book.readProgress?.page!!
+    } else {
+      return 1
+    }
+  }
+
+  public isCompleted (): Optional<boolean> {
+    return this.book.readProgress?.completed
+  }
+}
+
+export function computedSetting<V> (setting: string, save: boolean = true): any {
+  return {
+    get: function (): V {
+      return this.reader?.get(setting)
+    },
+    set: function (value: V) {
+      return this.reader?.set(setting, value, save)
+    },
+  }
+}

--- a/komga-webui/src/functions/reader.ts
+++ b/komga-webui/src/functions/reader.ts
@@ -7,8 +7,16 @@ import { Cookie, Mapper } from '@/functions/cookies'
 import { VueCookies } from 'vue-cookies'
 import { bookPageUrl } from '@/functions/urls'
 import { checkWebpFeature } from '@/functions/check-webp'
+import {
+  DoubleSpreadBuilder,
+  PageSpread,
+  PageSpreadBuilder, PageSpreads,
+  SingleSpreadBuilder,
+  WebToonBuilder,
+} from '@/functions/pages'
+import { VueRouter } from 'vue-router/types/router'
 
-type Optional<V> = V | undefined
+export type Optional<V> = V | undefined
 
 export enum ReaderSettings {
   DOUBLE_PAGES = 'webreader.doublePages',
@@ -38,6 +46,9 @@ export class Reader {
   public book: BookDto = {} as BookDto
   public series: SeriesDto = {} as SeriesDto
   public pages: PageDto[] = []
+  private _navigator: Optional<Navigator> = undefined
+  private _spreads: PageSpreads = {} as PageSpreads
+  pageSpreadBuild: PageSpreadBuilder
   bookId: string = ''
   loaded: boolean = false
 
@@ -50,6 +61,7 @@ export class Reader {
     this.$komgaSeries = $komgaSeries
     this.$cookie = $cookie
     this.defaultSettings()
+    this.pageSpreadBuild = new SingleSpreadBuilder(this.$komgaBooks)
 
     checkWebpFeature('lossy', (feature, isSupported) => {
       if (isSupported) {
@@ -84,7 +96,34 @@ export class Reader {
       setting.load()
     }
 
+    this.determinedSpreadBuilder()
+    await this.buildSpread()
     this.loaded = true
+  }
+
+  /*
+  @return true if builder changed
+   */
+  private determinedSpreadBuilder (): boolean {
+    let newBuilder
+    if (this.get(ReaderSettings.READ_DIR) === ReadingDirection.VERTICAL) {
+      newBuilder = new SingleSpreadBuilder(this.$komgaBooks)
+    } else if (this.get(ReaderSettings.DOUBLE_PAGES)) {
+      newBuilder = new DoubleSpreadBuilder(this.$komgaBooks)
+    } else {
+      newBuilder = new SingleSpreadBuilder(this.$komgaBooks)
+    }
+
+    if (newBuilder.constructor !== this.pageSpreadBuild.constructor) {
+      this.pageSpreadBuild = newBuilder
+      return true
+    }
+    return false
+  }
+
+  public async buildSpread () {
+    this._spreads = await this.pageSpreadBuild.getSpreads(this.book, this.pages)
+    this._navigator = new Navigator(this, this._spreads)
   }
 
   /*
@@ -103,10 +142,6 @@ export class Reader {
     return false
   }
 
-  public pagesCount () {
-    return this.pages.length
-  }
-
   public bookTitle () {
     if (this.book?.metadata && this.series?.metadata) {
       return getBookTitleCompact(this.book.metadata.title, this.series.metadata.title)
@@ -118,21 +153,21 @@ export class Reader {
     return c.get()
   }
 
-  public set<V> (name: string, value: V, save: boolean = true) {
+  public async set<V> (name: string, value: V, save: boolean = true) {
     let c = this.settings[name] as Cookie<V>
     c.set(value, save)
+    this.onSettingsChange()
   }
 
-  public getPageUrl (page: number): string {
-    if (!this.SUPPORTED_MEDIA_TYPES.includes(this.pages[page - 1].mediaType)) {
-      return bookPageUrl(this.bookId, page, this.convertTo)
-    } else {
-      return bookPageUrl(this.bookId, page)
+  private async onSettingsChange () {
+    // Only rebuild spread if the builder changed
+    if (this.determinedSpreadBuilder()) {
+      await this.buildSpread()
     }
   }
 
   public determinePage (page: number): number {
-    if (page >= 1 && page <= this.pagesCount()) {
+    if (page >= 1 && page <= this.navigator?.count!!) {
       return page
     } else if (!this.isCompleted()) {
       return this.book.readProgress?.page!!
@@ -144,6 +179,28 @@ export class Reader {
   public isCompleted (): Optional<boolean> {
     return this.book.readProgress?.completed
   }
+
+  get spreads (): PageSpreads {
+    return this._spreads
+  }
+
+  get navigator (): Optional<Navigator> {
+    return this._navigator
+  }
+
+  markProgress (page: number) {
+    if (page >= 1 && page <= this.pages.length) {
+      this.$komgaBooks.updateReadProgress(this.book.id, { page: page })
+    }
+  }
+}
+
+export function readSetting<V> (setting: string): any {
+  return {
+    get: function (): V {
+      return this.reader?.get(setting)
+    },
+  }
 }
 
 export function computedSetting<V> (setting: string, save: boolean = true): any {
@@ -154,5 +211,121 @@ export function computedSetting<V> (setting: string, save: boolean = true): any 
     set: function (value: V) {
       return this.reader?.set(setting, value, save)
     },
+  }
+}
+
+export class Navigator {
+  private _pageCursor: number
+  private spreads : PageSpreads
+  private reader: Reader
+
+  constructor (reader: Reader, spreads: PageSpreads) {
+    this._pageCursor = 1
+    this.reader = reader
+    this.spreads = spreads
+  }
+
+  get pageCursor (): number {
+    return this._pageCursor
+  }
+
+  set pageCursor (value: number) {
+    this._pageCursor = value
+  }
+
+  get count (): number {
+    return this.spreads?.spreads?.length!!
+  }
+
+  get progress (): number {
+    return (this.realPageNumber / this.realPageCount) * 100
+  }
+
+  get realPageNumber (): number {
+    return this.spreads.spreads[this.pageCursor]?.pages[0]?.number
+  }
+
+  get realPageCount (): number {
+    return this.reader.pages.length
+  }
+
+  goToFirst (): void {
+    this.goTo(1)
+  }
+
+  goToLast (): void {
+    this.goTo(this.count - 1)
+  }
+
+  goTo (page: number): void {
+    this.pageCursor = this.reader?.spreads.indexOf.get(page)!!
+  }
+
+  forward (force: boolean = false) {
+    if (!force && this.isVertical()) return
+    return this.flipDirection() ? this.next() : this.prev()
+  }
+
+  backward (force: boolean = false) {
+    if (!force && this.isVertical()) return
+    return this.flipDirection() ? this.prev() : this.next()
+  }
+
+  up () {
+    if (this.isVertical()) {
+      this.prev()
+    }
+  }
+
+  down () {
+    if (this.isVertical()) {
+      this.next()
+    }
+  }
+
+  vtouch () {
+    let swipe = this.swipe()
+    return {
+      left: () => { if (swipe) { this.forward() } },
+      right: () => { if (swipe) { this.backward() } },
+      up: () => { if (swipe) { this.down() } },
+      down: () => { if (swipe) { this.up() } },
+    }
+  }
+
+  private swipe (): boolean {
+    return this.reader.get(ReaderSettings.SWIPE)
+  }
+
+  private flipDirection (): boolean {
+    return this.reader.get(ReaderSettings.READ_DIR) === ReadingDirection.LEFT_TO_RIGHT
+  }
+
+  private isVertical (): boolean {
+    return this.reader.get(ReaderSettings.READ_DIR) === ReadingDirection.VERTICAL
+  }
+
+  private hasNext () {
+    return this._pageCursor < this.count
+  }
+
+  private hasPrev () {
+    return this._pageCursor >= 1
+  }
+
+  private next () {
+    if (this.hasNext()) {
+      this._pageCursor++
+    }
+  }
+
+  private prev () {
+    if (this.hasPrev()) {
+      this._pageCursor--
+    }
+  }
+
+  goToBook ($router: VueRouter, sibling: BookDto) {
+    $router.push({ name: 'read-book', params: { bookId: sibling.id.toString()!! } })
   }
 }

--- a/komga-webui/src/functions/reader.ts
+++ b/komga-webui/src/functions/reader.ts
@@ -1,5 +1,5 @@
 import KomgaBooksService from '@/services/komga-books.service'
-import { ImageFit, ReadingDirection } from '@/types/enum-books'
+import { BackgroundColors, ImageFit, ReadingDirection } from '@/types/enum-books'
 import { Map } from '@/functions/forms'
 import KomgaSeriesService from '@/services/komga-series.service'
 import { getBookTitleCompact } from '@/functions/book-title'
@@ -68,7 +68,7 @@ export class Reader {
     this.addSetting(ReaderSettings.ANIMATIONS, true, TRUE_MAPPER)
     this.addSetting(ReaderSettings.FIT, ImageFit.HEIGHT, IDENTITY_MAPPER)
     this.addSetting(ReaderSettings.READ_DIR, ReadingDirection.LEFT_TO_RIGHT, IDENTITY_MAPPER)
-    this.addSetting(ReaderSettings.BG_COLOR, 'black', IDENTITY_MAPPER)
+    this.addSetting(ReaderSettings.BG_COLOR, BackgroundColors.BLACK, IDENTITY_MAPPER)
   }
 
   public async setup (bookId: string) {

--- a/komga-webui/src/functions/shortcuts.ts
+++ b/komga-webui/src/functions/shortcuts.ts
@@ -49,30 +49,17 @@ enum ShortcutCategory {
 
 // Reader Navigation
 shortcut('seekForward', ShortcutCategory.READER_NAVIGATION, 'Next Page',
-  (ctx: any) => {
-    ctx.flipDirection ? ctx.prev() : ctx.next()
-  }, 'PageUp', 'ArrowRight')
+  (ctx: any) => ctx.nav.forward(), 'PageUp', 'ArrowRight')
 
 shortcut('seekBackward', ShortcutCategory.READER_NAVIGATION, 'Prev Page',
-  (ctx: any) => {
-    ctx.flipDirection ? ctx.next() : ctx.prev()
-  }, 'PageDown', 'ArrowLeft')
+  (ctx: any) => ctx.nav.backward(), 'PageDown', 'ArrowLeft')
 
 shortcut('seekUp', ShortcutCategory.READER_NAVIGATION, 'Prev Page (Vertical)',
-  (ctx: any) => {
-    if (ctx.vertical) {
-      ctx.prev()
-    }
-  }
+  (ctx: any) => ctx.nav.up()
   , 'ArrowUp')
 
 shortcut('seekDown', ShortcutCategory.READER_NAVIGATION, 'Next Page (Vertical)',
-  (ctx: any) => {
-    if (ctx.vertical) {
-      ctx.next()
-    }
-  }
-  , 'ArrowDown')
+  (ctx: any) => ctx.nav.down(), 'ArrowDown')
 
 shortcut('seekBegin', ShortcutCategory.READER_NAVIGATION, 'Goto First Page',
   (ctx: any) => {

--- a/komga-webui/src/functions/shortcuts.ts
+++ b/komga-webui/src/functions/shortcuts.ts
@@ -1,23 +1,5 @@
 import { ReadingDirection } from '@/types/enum-books'
-
-interface Map<V> {
-  [key: string]: V
-}
-class MultiMap<V> {
-  dict: Map<V[]> = {}
-
-  add (key:string, value: V) {
-    this.dict[key] = (this.dict[key]?.concat([value])) || [value]
-  }
-
-  get (key: string): V[] {
-    return this.dict[key]
-  }
-
-  items () {
-    return Object.keys(this.dict).map((k) => ({ key: k, value: this.dict[k] }))
-  }
-}
+import { Map, MultiMap } from '@/functions/forms'
 
 type Action = (ctx: any) => void
 

--- a/komga-webui/src/types/enum-books.ts
+++ b/komga-webui/src/types/enum-books.ts
@@ -1,8 +1,28 @@
+import { SelectItem } from '@/functions/forms'
+// TODO eslint-disable needed for declaration merging, need to decide if want to globally disable?
+
+// eslint-disable-next-line import/export
 export enum ReadingDirection {
   LEFT_TO_RIGHT = 'LEFT_TO_RIGHT',
   RIGHT_TO_LEFT = 'RIGHT_TO_LEFT',
   VERTICAL = 'VERTICAL',
   WEBTOON = 'WEBTOON'
+}
+export const READING_DIRECTIONS = Object.values(ReadingDirection)
+
+export const READING_DIR_ITEMS = [
+  { text: 'Left to right', value: ReadingDirection.LEFT_TO_RIGHT },
+  { text: 'Right to left', value: ReadingDirection.RIGHT_TO_LEFT },
+  { text: 'Vertical', value: ReadingDirection.VERTICAL },
+] as SelectItem<ReadingDirection>[]
+
+// eslint-disable-next-line no-redeclare,import/export
+export namespace ReadingDirection {
+  // eslint-disable-next-line no-inner-declarations
+  export function toString (o: ReadingDirection): string {
+    let i = READING_DIRECTIONS.indexOf(o)
+    return READING_DIR_ITEMS[i].text
+  }
 }
 
 export enum MediaStatus {
@@ -12,9 +32,51 @@ export enum MediaStatus {
   UNSUPPORTED = 'UNSUPPORTED',
   OUTDATED = 'OUTDATED'
 }
+export const MEDIA_STATUES = Object.values(MediaStatus)
 
 export enum ReadStatus {
   UNREAD = 'UNREAD',
   IN_PROGRESS = 'IN_PROGRESS',
   READ = 'READ'
 }
+export const READ_STATUSES = Object.values(ReadStatus)
+
+// eslint-disable-next-line import/export
+export enum ImageFit {
+  WIDTH = 'width',
+  HEIGHT = 'height',
+  ORIGINAL = 'original'
+}
+export const IMAGE_FITS = Object.values(ImageFit)
+
+export const IMAGE_FIT_ITEMS = [
+  { text: 'Fit to height', value: ImageFit.HEIGHT },
+  { text: 'Fit to width', value: ImageFit.WIDTH },
+  { text: 'Original', value: ImageFit.ORIGINAL },
+] as SelectItem<ImageFit>[]
+
+// eslint-disable-next-line no-redeclare,import/export
+export namespace ImageFit {
+  // eslint-disable-next-line no-inner-declarations
+  export function toString (o: ImageFit): string {
+    let i = IMAGE_FITS.indexOf(o)
+    return IMAGE_FIT_ITEMS[i].text
+  }
+  // eslint-disable-next-line no-inner-declarations
+  export function next (o: ImageFit): ImageFit {
+    let i = (IMAGE_FITS.indexOf(o) + 1) % (IMAGE_FITS.length)
+    return IMAGE_FITS[i] as ImageFit
+  }
+}
+
+// eslint-disable-next-line import/export
+export enum BackgroundColors {
+  WHITE = 'white',
+  BLACK = 'black',
+}
+export const BACKGROUND_COLORS = Object.values(BackgroundColors)
+
+export const BACKGROUND_COLOR_ITEMS = [
+  { text: 'White', value: BackgroundColors.WHITE },
+  { text: 'Black', value: BackgroundColors.BLACK },
+] as SelectItem<BackgroundColors>[]

--- a/komga-webui/src/types/enum-books.ts
+++ b/komga-webui/src/types/enum-books.ts
@@ -21,7 +21,10 @@ export namespace ReadingDirection {
   // eslint-disable-next-line no-inner-declarations
   export function toString (o: ReadingDirection): string {
     let i = READING_DIRECTIONS.indexOf(o)
-    return READING_DIR_ITEMS[i].text
+    if (i >= 0 && i < READING_DIR_ITEMS.length) {
+      return READING_DIR_ITEMS[i].text
+    }
+    return 'Unknown'
   }
 }
 
@@ -50,8 +53,8 @@ export enum ImageFit {
 export const IMAGE_FITS = Object.values(ImageFit)
 
 export const IMAGE_FIT_ITEMS = [
-  { text: 'Fit to height', value: ImageFit.HEIGHT },
   { text: 'Fit to width', value: ImageFit.WIDTH },
+  { text: 'Fit to height', value: ImageFit.HEIGHT },
   { text: 'Original', value: ImageFit.ORIGINAL },
 ] as SelectItem<ImageFit>[]
 

--- a/komga-webui/src/views/BookReader.vue
+++ b/komga-webui/src/views/BookReader.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-container class="ma-0 pa-0 full-height" fluid v-if="pages.length > 0"
+  <v-container class="ma-0 pa-0 full-height" fluid v-if="pagesCount > 0"
                :style="`width: 100%; background-color: ${backgroundColor}`"
                v-touch="{
                  left: () => {if(swipe) {turnRight()}},
@@ -7,6 +7,7 @@
                  up: () => {if(swipe) {verticalNext()}},
                  down: () => {if(swipe) {verticalPrev()}}
                  }"
+               :key="this.bookId"
   >
     <div>
       <v-slide-y-transition>
@@ -53,30 +54,30 @@
           <v-row justify="center">
             <!--  Menu: page slider  -->
             <v-col class="px-0">
-                <v-slider
-                  hide-details
-                  thumb-label
-                  @change="goTo"
-                  v-model="goToPage"
-                  class="align-center"
-                  min="1"
-                  :max="pagesCount"
-                >
-                  <template v-slot:prepend>
-                    <v-icon @click="previousBook" class="">mdi-undo</v-icon>
-                    <v-icon @click="goToFirst" class="mx-2">mdi-skip-previous</v-icon>
-                    <v-label>
-                      {{ currentPage }}
-                    </v-label>
-                  </template>
-                  <template v-slot:append>
-                    <v-label>
-                      {{ pagesCount }}
-                    </v-label>
-                    <v-icon @click="goToLast" class="mx-1">mdi-skip-next</v-icon>
-                    <v-icon @click="nextBook" class="">mdi-redo</v-icon>
-                  </template>
-                </v-slider>
+              <v-slider
+                hide-details
+                thumb-label
+                @change="changeSlider"
+                v-model="goToPage"
+                class="align-center"
+                min="1"
+                :max="pagesCount"
+              >
+                <template v-slot:prepend>
+                  <v-icon @click="previousBook" class="">mdi-undo</v-icon>
+                  <v-icon @click="goToFirst" class="mx-2">mdi-skip-previous</v-icon>
+                  <v-label>
+                    {{ currentPage }}
+                  </v-label>
+                </template>
+                <template v-slot:append>
+                  <v-label>
+                    {{ pagesCount }}
+                  </v-label>
+                  <v-icon @click="goToLast" class="mx-1">mdi-skip-next</v-icon>
+                  <v-icon @click="nextBook" class="">mdi-redo</v-icon>
+                </template>
+              </v-slider>
             </v-col>
           </v-row>
 
@@ -105,6 +106,7 @@
     <div class="full-height">
       <!--  Carousel  -->
       <v-carousel v-model="carouselPage"
+                  :value="10"
                   :show-arrows="false"
                   :continuous="false"
                   :reverse="flipDirection"
@@ -142,8 +144,8 @@
 
     <thumbnail-explorer-dialog
       v-model="showThumbnailsExplorer"
-      :bookId="bookId"
       @goToPage="goTo"
+      :bookId="bookId"
       :pagesCount="pagesCount"
     ></thumbnail-explorer-dialog>
 
@@ -177,7 +179,7 @@
 
           <v-list-item>
             <settings-select
-              :items="backgroundColors"
+              :items="formValues.backgroundColors"
               v-model="backgroundColor"
               label="Background color"
             >
@@ -186,7 +188,7 @@
 
           <v-list-item>
             <settings-select
-              :items="readingDirs"
+              :items="formValues.readingDirs"
               v-model="readingDirection"
               label="Reading Direction"
             />
@@ -194,7 +196,7 @@
 
           <v-list-item>
             <settings-select
-              :items="imageFits"
+              :items="formValues.imageFits"
               v-model="imageFit"
               label="Scaling"
             />
@@ -203,6 +205,7 @@
       </v-container>
     </v-bottom-sheet>
     <v-snackbar
+      v-if="reader && reader.loaded"
       v-model="jumpToPreviousBook"
       :timeout="jumpConfirmationDelay"
       vertical
@@ -213,11 +216,12 @@
     >
       <div class="title pa-6">
         <p>You're at the beginning<br/>of the book.</p>
-        <p v-if="!$_.isEmpty(siblingPrevious)">Click or press previous again<br/>to move to the previous book.</p>
+        <p v-if="siblingPrevious">Click or press previous again<br/>to move to the previous book.</p>
       </div>
     </v-snackbar>
 
     <v-snackbar
+      v-if="reader && reader.loaded"
       v-model="jumpToNextBook"
       :timeout="jumpConfirmationDelay"
       vertical
@@ -228,7 +232,7 @@
     >
       <div class="title pa-6">
         <p>You've reached the end<br/>of the book.</p>
-        <p v-if="!$_.isEmpty(siblingNext)">Click or press next again<br/>to move to the next book.</p>
+        <p v-if="siblingNext">Click or press next again<br/>to move to the next book.</p>
         <p v-else>Click or press next again<br/>to exit the reader.</p>
       </div>
     </v-snackbar>
@@ -240,7 +244,7 @@
                 top
     >
       <div>This book has specific reading direction set.</div>
-      <div>Reading direction has been set to <span class="font-weight-bold">{{ readingDirs.find(x => x.value === readingDirection).text }}</span>.
+      <div>Reading direction has been set to <span class="font-weight-bold">{{ ReadingDirection.toString(readingDirection) }}</span>.
       </div>
       <div>This only applies to this book and will not overwrite your settings.</div>
       <v-btn
@@ -272,114 +276,52 @@ import SettingsSelect from '@/components/SettingsSelect.vue'
 import SettingsSwitch from '@/components/SettingsSwitch.vue'
 import ThumbnailExplorerDialog from '@/components/dialogs/ThumbnailExplorerDialog.vue'
 import ShortcutHelpMenu from '@/components/menus/ShortcutHelpMenu.vue'
-import { getBookTitleCompact } from '@/functions/book-title'
-import { checkWebpFeature } from '@/functions/check-webp'
-import { bookPageUrl } from '@/functions/urls'
-import { ReadingDirection } from '@/types/enum-books'
+import {
+  ReadingDirection,
+  ImageFit,
+  READING_DIR_ITEMS,
+  IMAGE_FIT_ITEMS,
+  BACKGROUND_COLOR_ITEMS,
+} from '@/types/enum-books'
 import { executeShortcut } from '@/functions/shortcuts'
+
+import { Reader, computedSetting, ReaderSettings } from '@/functions/reader'
 import Vue from 'vue'
 
-const cookieFit = 'webreader.fit'
-const cookieReadingDirection = 'webreader.readingDirection'
-const cookieDoublePages = 'webreader.doublePages'
-const cookieSwipe = 'webreader.swipe'
-const cookieAnimations = 'webreader.animations'
-const cookieBackground = 'webreader.background'
-
-enum ImageFit {
-  WIDTH = 'width',
-  HEIGHT = 'height',
-  ORIGINAL = 'original'
-}
+type _reader = Reader | undefined
 
 export default Vue.extend({
   name: 'BookReader',
   components: { SettingsSwitch, SettingsSelect, ThumbnailExplorerDialog, ShortcutHelpMenu },
   data: () => {
     return {
-      ImageFit,
-      book: {} as BookDto,
-      series: {} as SeriesDto,
-      siblingPrevious: {} as BookDto,
-      siblingNext: {} as BookDto,
+      reader: undefined as _reader,
+      carouselPage: 1,
+      goToPage: 1,
       jumpToNextBook: false,
       jumpToPreviousBook: false,
       jumpConfirmationDelay: 3000,
       snackReadingDirection: false,
-      pages: [] as PageDto[],
-      supportedMediaTypes: ['image/jpeg', 'image/png', 'image/gif'],
-      convertTo: 'jpeg',
-      carouselPage: 0,
       showThumbnailsExplorer: false,
       toolbar: false,
       menu: false,
       dialogGoto: false,
-      goToPage: 1,
-      settings: {
-        doublePages: false,
-        swipe: true,
-        fit: ImageFit.HEIGHT,
-        readingDirection: ReadingDirection.LEFT_TO_RIGHT,
-        animations: true,
-        backgroundColor: 'black',
-        imageFits: Object.values(ImageFit),
-        readingDirs: Object.values(ReadingDirection),
-      },
       notification: {
         enabled: false,
         message: '',
         timeout: 4000,
       },
-      readingDirs: [
-        { text: 'Left to right', value: ReadingDirection.LEFT_TO_RIGHT },
-        { text: 'Right to left', value: ReadingDirection.RIGHT_TO_LEFT },
-        { text: 'Vertical', value: ReadingDirection.VERTICAL },
-      ],
-      imageFits: [
-        { text: 'Fit to height', value: ImageFit.HEIGHT },
-        { text: 'Fit to width', value: ImageFit.WIDTH },
-        { text: 'Original', value: ImageFit.ORIGINAL },
-      ],
-      backgroundColors: [
-        { text: 'White', value: 'white' },
-        { text: 'Black', value: 'black' },
-      ],
+      formValues: {
+        readingDirs: READING_DIR_ITEMS,
+        imageFits: IMAGE_FIT_ITEMS,
+        backgroundColors: BACKGROUND_COLOR_ITEMS,
+      },
+      ReadingDirection,
     }
-  },
-  created () {
-    checkWebpFeature('lossy', (feature, isSupported) => {
-      if (isSupported) {
-        this.supportedMediaTypes.push('image/webp')
-      }
-    })
   },
   async mounted () {
     window.addEventListener('keydown', this.keyPressed)
-
-    this.loadFromCookie(cookieReadingDirection, (v) => {
-      this.readingDirection = v
-    })
-    this.loadFromCookie(cookieAnimations, (v) => {
-      this.animations = (v === 'true')
-    })
-    this.loadFromCookie(cookieDoublePages, (v) => {
-      this.doublePages = (v === 'true')
-    })
-    this.loadFromCookie(cookieSwipe, (v) => {
-      this.swipe = (v === 'true')
-    })
-    this.loadFromCookie(cookieFit, (v) => {
-      if (v) {
-        this.imageFit = v
-      }
-    })
-    this.loadFromCookie(cookieBackground, (v) => {
-      if (v) {
-        this.backgroundColor = v
-      }
-    })
-
-    this.setup(this.bookId, Number(this.$route.query.page))
+    await this.setup(this.bookId, Number(this.$route.query.page))
   },
   destroyed () {
     window.removeEventListener('keydown', this.keyPressed)
@@ -390,24 +332,21 @@ export default Vue.extend({
       required: true,
     },
   },
-  async beforeRouteUpdate (to, from, next) {
-    if (to.params.bookId !== from.params.bookId) {
-      // route update means going to previous/next book, in this case we start from first page
-      this.setup(to.params.bookId, 1)
-    }
-    next()
-  },
+  // async beforeRouteUpdate (to, from, next) {
+  //   if (to.params.bookId !== from.params.bookId) {
+  //     // route update means going to previous/next book, in this case we start from first page
+  //     this.setup(to.params.bookId, 0)
+  //   }
+  //   next()
+  // },
   watch: {
     currentPage (val) {
       this.updateRoute()
       this.goToPage = val
       this.markProgress(val)
     },
-    async book (val) {
-      if (this.$_.has(val, 'name')) {
-        this.series = await this.$komgaSeries.getOneSeries(val.seriesId)
-        document.title = `Komga - ${getBookTitleCompact(val.metadata.title, this.series.metadata.title)}`
-      }
+    async bookId (val) {
+      await this.setup(val, 0)
     },
   },
   computed: {
@@ -446,29 +385,10 @@ export default Vue.extend({
       return this.slidesRange.length
     },
     pagesCount (): number {
-      return this.pages.length
+      return this.reader?.pagesCount()!!
     },
     bookTitle (): string {
-      return getBookTitleCompact(this.book.metadata.title, this.series.metadata.title)
-    },
-
-    animations: {
-      get: function (): boolean {
-        return this.settings.animations
-      },
-      set: function (animations: boolean): void {
-        this.settings.animations = animations
-        this.$cookies.set(cookieAnimations, animations, Infinity)
-      },
-    },
-    readingDirection: {
-      get: function (): ReadingDirection {
-        return this.settings.readingDirection
-      },
-      set: function (readingDirection: ReadingDirection): void {
-        this.settings.readingDirection = readingDirection
-        this.$cookies.set(cookieReadingDirection, readingDirection, Infinity)
-      },
+      return this.reader?.bookTitle()!!
     },
     flipDirection (): boolean {
       return this.readingDirection === ReadingDirection.RIGHT_TO_LEFT
@@ -476,90 +396,33 @@ export default Vue.extend({
     vertical (): boolean {
       return this.readingDirection === ReadingDirection.VERTICAL
     },
-    imageFit: {
-      get: function (): ImageFit {
-        return this.settings.fit
-      },
-      set: function (fit: ImageFit): void {
-        this.settings.fit = fit
-        this.$cookies.set(cookieFit, fit, Infinity)
-      },
+    siblingPrevious (): BookDto {
+      return this.reader?.siblingPrev!!
     },
-    backgroundColor: {
-      get: function (): string {
-        return this.settings.backgroundColor
-      },
-      set: function (color: string): void {
-        this.settings.backgroundColor = color
-        this.$cookies.set(cookieBackground, color, Infinity)
-      },
+    siblingNext (): BookDto {
+      return this.reader?.siblingNext!!
     },
-    doublePages: {
-      get: function (): boolean {
-        return this.settings.doublePages
-      },
-      set: function (doublePages: boolean): void {
-        const current = this.currentPage
-        this.settings.doublePages = doublePages
-        this.goTo(current)
-        this.$cookies.set(cookieDoublePages, doublePages, Infinity)
-      },
-    },
-    swipe: {
-      get: function (): boolean {
-        return this.settings.swipe
-      },
-      set: function (swipe: boolean): void {
-        this.settings.swipe = swipe
-        this.$cookies.set(cookieSwipe, swipe, Infinity)
-      },
-    },
+    imageFit: computedSetting<ImageFit>(ReaderSettings.FIT),
+    backgroundColor: computedSetting<string>(ReaderSettings.BG_COLOR),
+    readingDirection: computedSetting<ReadingDirection>(ReaderSettings.READ_DIR),
+    doublePages: computedSetting<boolean>(ReaderSettings.DOUBLE_PAGES),
+    swipe: computedSetting<boolean>(ReaderSettings.SWIPE),
+    animations: computedSetting<boolean>(ReaderSettings.ANIMATIONS),
   },
   methods: {
     keyPressed (e: KeyboardEvent) {
       executeShortcut(this, e)
     },
     async setup (bookId: string, page: number) {
-      this.book = await this.$komgaBooks.getBook(bookId)
-      this.pages = await this.$komgaBooks.getBookPages(bookId)
-      if (page >= 1 && page <= this.pagesCount) {
-        this.goTo(page)
-      } else if (this.book.readProgress?.completed === false) {
-        this.goTo(this.book.readProgress?.page!!)
-      } else {
-        this.goToFirst()
-      }
-
-      // set non-persistent reading direction if exists in metadata
-      switch (this.book.metadata.readingDirection) {
-        case ReadingDirection.LEFT_TO_RIGHT:
-        case ReadingDirection.RIGHT_TO_LEFT:
-        case ReadingDirection.VERTICAL:
-          if (this.readingDirection !== this.book.metadata.readingDirection) {
-            // bypass setter so cookies aren't set
-            this.settings.readingDirection = this.book.metadata.readingDirection
-            this.snackReadingDirection = true
-          }
-          break
-      }
-
-      try {
-        this.siblingNext = await this.$komgaBooks.getBookSiblingNext(bookId)
-      } catch (e) {
-        this.siblingNext = {} as BookDto
-      }
-      try {
-        this.siblingPrevious = await this.$komgaBooks.getBookSiblingPrevious(bookId)
-      } catch (e) {
-        this.siblingPrevious = {} as BookDto
-      }
+      this.reader = new Reader(this.$komgaBooks, this.$komgaSeries, this.$cookies)
+      await this.reader.setup(this.bookId)
+      document.title = `Komga - ${this.reader.bookTitle()}`
+      this.snackReadingDirection = this.reader?.coerceReadingDirection()
+      const p = this.reader.determinePage(page)
+      this.goTo(p)
     },
     getPageUrl (page: number): string {
-      if (!this.supportedMediaTypes.includes(this.pages[page - 1].mediaType)) {
-        return bookPageUrl(this.bookId, page, this.convertTo)
-      } else {
-        return bookPageUrl(this.bookId, page)
-      }
+      return this.reader?.getPageUrl(page)!!
     },
     turnRight () {
       if (this.vertical) return
@@ -600,18 +463,21 @@ export default Vue.extend({
       }
     },
     nextBook () {
-      if (this.$_.isEmpty(this.siblingNext)) {
-        this.closeBook()
-      } else {
+      if (this.siblingNext) {
         this.jumpToNextBook = false
         this.$router.push({ name: 'read-book', params: { bookId: this.siblingNext.id.toString() } })
+      } else {
+        this.closeBook()
       }
     },
     previousBook () {
-      if (!this.$_.isEmpty(this.siblingPrevious)) {
+      if (this.siblingPrevious) {
         this.jumpToPreviousBook = false
         this.$router.push({ name: 'read-book', params: { bookId: this.siblingPrevious.id.toString() } })
       }
+    },
+    changeSlider (page: number) {
+      this.goTo(page)
     },
     goTo (page: number) {
       this.carouselPage = this.doublePages ? this.toDoublePages(page) - 1 : page - 1
@@ -658,75 +524,68 @@ export default Vue.extend({
       }
       return this.$vuetify.breakpoint.width
     },
-    loadFromCookie (cookieKey: string, setter: (value: any) => void): void {
-      if (this.$cookies.isKey(cookieKey)) {
-        let value = this.$cookies.get(cookieKey)
-        setter(value)
-      }
-    },
     changeReadingDir (dir: ReadingDirection) {
-      this.readingDirection = dir
-      let i = this.settings.readingDirs.indexOf(this.readingDirection)
-      let text = this.readingDirs[i].text
-      this.sendNotification(`Changing Reading Direction to: ${text}`)
+      this.reader?.set(ReaderSettings.READ_DIR, dir)
+      this.sendNotification(`Changing Reading Direction to: ${ReadingDirection.toString(dir)}`)
     },
     cycleScale () {
-      let fit: ImageFit = this.settings.fit
-      let i = (this.settings.imageFits.indexOf(fit) + 1) % (this.settings.imageFits.length)
-      this.settings.fit = this.settings.imageFits[i]
-      let text = this.imageFits[i].text
-      // The text here only works cause this.imageFits has the same index structure as the ImageFit enum
-      this.sendNotification(`Cycling Scale: ${text}`)
+      let fit: ImageFit = this.reader?.get<ImageFit>(ReaderSettings.FIT)!!
+      let next = ImageFit.next(fit)
+      this.reader?.set(ReaderSettings.READ_DIR, next)
+      this.sendNotification(`Cycling Scale: ${ImageFit.toString(next)}`)
     },
     toggleDoublePages () {
       this.doublePages = !this.doublePages
       this.sendNotification(`${this.doublePages ? 'Enabled' : 'Disabled'} Double Pages`)
     },
-    sendNotification (message:string, timeout: number = 4000) {
+    sendNotification (message: string, timeout: number = 4000) {
       this.notification.timeout = 4000
       this.notification.message = message
       this.notification.enabled = true
     },
     async markProgress (page: number) {
-      this.$komgaBooks.updateReadProgress(this.bookId, { page: page })
+      // TODO something is causing the initially loaded book to be a page that very much does not exist???
+      if (page <= this.pagesCount) {
+        this.$komgaBooks.updateReadProgress(this.bookId, { page: page })
+      }
     },
   },
 })
 </script>
 
 <style scoped>
-.settings {
-  /*position: absolute;*/
-  z-index: 2;
-}
+  .settings {
+    /*position: absolute;*/
+    z-index: 2;
+  }
 
-.top {
-  top: 0;
-}
+  .top {
+    top: 0;
+  }
 
-.full-height {
-  height: 100%;
-}
+  .full-height {
+    height: 100%;
+  }
 
-.full-width {
-  width: 100%;
-}
+  .full-width {
+    width: 100%;
+  }
 
-.left-quarter {
-  left: 0;
-  width: 20%;
-  position: absolute;
-}
+  .left-quarter {
+    left: 0;
+    width: 20%;
+    position: absolute;
+  }
 
-.right-quarter {
-  right: 0;
-  width: 20%;
-  position: absolute;
-}
+  .right-quarter {
+    right: 0;
+    width: 20%;
+    position: absolute;
+  }
 
-.center-half {
-  left: 20%;
-  width: 60%;
-  position: absolute;
-}
+  .center-half {
+    left: 20%;
+    width: 60%;
+    position: absolute;
+  }
 </style>

--- a/komga-webui/src/views/BookReader.vue
+++ b/komga-webui/src/views/BookReader.vue
@@ -16,7 +16,7 @@
         >
           <v-btn
             icon
-            @click="closeBook"
+            @click="nav.closeBook"
           >
             <v-icon>mdi-arrow-left</v-icon>
           </v-btn>
@@ -61,7 +61,7 @@
                 :max="realPageCount"
               >
                 <template v-slot:prepend>
-                  <v-icon @click="previousBook" class="">mdi-undo</v-icon>
+                  <v-icon @click="nav.prevBook" class="">mdi-undo</v-icon>
                   <v-icon @click="goToFirst" class="mx-2">mdi-skip-previous</v-icon>
                   <v-label>
                     {{ realPageNumber }}
@@ -72,7 +72,7 @@
                     {{ realPageCount }}
                   </v-label>
                   <v-icon @click="goToLast" class="mx-1">mdi-skip-next</v-icon>
-                  <v-icon @click="nextBook" class="">mdi-redo</v-icon>
+                  <v-icon @click="nav.nextBook" class="">mdi-redo</v-icon>
                 </template>
               </v-slider>
             </v-col>
@@ -174,7 +174,7 @@
     </v-bottom-sheet>
     <v-snackbar
       v-if="reader && reader.loaded"
-      v-model="jumpToPreviousBook"
+      v-model="nav.jump.prevBook"
       :timeout="jumpConfirmationDelay"
       vertical
       top
@@ -190,7 +190,7 @@
 
     <v-snackbar
       v-if="reader && reader.loaded"
-      v-model="jumpToNextBook"
+      v-model="nav.jump.nextBook"
       :timeout="jumpConfirmationDelay"
       vertical
       top
@@ -364,50 +364,12 @@ export default Vue.extend({
       executeShortcut(this, e)
     },
     async setup (bookId: string, page: number) {
-      this.reader = new Reader(this.$komgaBooks, this.$komgaSeries, this.$cookies)
+      this.reader = new Reader(this.$komgaBooks, this.$komgaSeries, this.$cookies, this.$router)
       await this.reader.setup(this.bookId)
       document.title = `Komga - ${this.reader.bookTitle()}`
       this.snackReadingDirection = this.reader?.coerceReadingDirection()
       const p = this.reader.determinePage(page)
       this.goTo(p)
-    },
-    // prev () {
-    //   if (this.canPrev) {
-    //     this.carouselPage--
-    //     window.scrollTo(0, 0)
-    //   } else {
-    //     if (this.jumpToPreviousBook) {
-    //       this.previousBook()
-    //     } else {
-    //       this.jumpToPreviousBook = true
-    //     }
-    //   }
-    // },
-    // next () {
-    //   if (this.canNext) {
-    //     this.carouselPage++
-    //     window.scrollTo(0, 0)
-    //   } else {
-    //     if (this.jumpToNextBook) {
-    //       this.nextBook()
-    //     } else {
-    //       this.jumpToNextBook = true
-    //     }
-    //   }
-    // },
-    nextBook () {
-      if (this.siblingNext) {
-        this.jumpToNextBook = false
-        this.nav.goToBook(this.$router, this.siblingNext!!)
-      } else {
-        this.closeBook()
-      }
-    },
-    previousBook () {
-      this.jumpToPreviousBook = false
-      if (this.siblingPrevious) {
-        this.nav.goToBook(this.$router, this.siblingPrevious!!)
-      }
     },
     changeSlider (page: number) {
       this.goTo(page)
@@ -431,9 +393,6 @@ export default Vue.extend({
           },
         })
       }
-    },
-    closeBook () {
-      this.$router.push({ name: 'browse-book', params: { bookId: this.bookId.toString() } })
     },
     changeReadingDir (dir: ReadingDirection) {
       this.reader?.set(ReaderSettings.READ_DIR, dir)


### PR DESCRIPTION
This is a rather large refactor of the BookReader view.

**What changed:**
It extracts much of the logic for gathering book information and settings for the reader to a external handling class Reader.

Settings for the reader have been merged into a registry of sort, allowing their computed property to be generated from a standard function. ex: 
```
computed: {
   imageFit: computedSetting<ImageFit>(ReaderSettings.FIT),
}
```
These settings use the new utilitiy class Cookie, that handles all the VueCookie logic for a specific value. I intended to do a pass and replace all $cookie references to this to have it standardized.

Also, enum-books nows contains the list of form values {text,value} as well as a namespace (using declaration merging) to have a toString function for some of the enums.

**Why:**
Extracting all of this logic has made the view much easier to ingest and will make it less fragile to small changes, and will hopefully make it easier to add other potential features like the WebToon view.

**More**

I'm considering also extracting the page number calculations with the intent to make coercing double pages for spanning images easier.


Let me know your thoughts!
