### PR TITLE
fix(metadata): recognize ComicInfo Day tag and "MA15+" rating

### DIFF
--- a/komga/src/main/kotlin/org/gotson/komga/infrastructure/metadata/comicinfo/ComicInfoProvider.kt
+++ b/komga/src/main/kotlin/org/gotson/komga/infrastructure/metadata/comicinfo/ComicInfoProvider.kt
@@ -30,7 +30,7 @@ class ComicInfoProvider(
   override fun getBookMetadataFromBook(book: Book, media: Media): BookMetadataPatch? {
     getComicInfo(book, media)?.let { comicInfo ->
       val releaseDate = comicInfo.year?.let {
-        LocalDate.of(comicInfo.year!!, comicInfo.month ?: 1, 1)
+        LocalDate.of(comicInfo.year!!, comicInfo.month ?: 1, comicInfo.day ?: 1)
       }
 
       val authors = mutableListOf<Author>()

--- a/komga/src/main/kotlin/org/gotson/komga/infrastructure/metadata/comicinfo/dto/AgeRating.kt
+++ b/komga/src/main/kotlin/org/gotson/komga/infrastructure/metadata/comicinfo/dto/AgeRating.kt
@@ -12,7 +12,6 @@ enum class AgeRating(val value: String, val ageRating: Int? = null) {
   KIDS_TO_ADULTS("Kids to Adults", 6),
   M("M", 17),
   MA_15("MA 15+", 15),
-  MA_15_NOSPACE("MA15+", 15),
   MATURE_17("Mature 17+", 17),
   PG("PG", 8),
   R_18("R18+", 18),
@@ -21,10 +20,12 @@ enum class AgeRating(val value: String, val ageRating: Int? = null) {
   X_18("X18+", 18);
 
   companion object {
-    private val map = values().associateBy(AgeRating::value)
+    private val map = values().associateBy { it.value.toLowerNoSpace() }
 
     @JvmStatic
     @JsonCreator
-    fun fromValue(value: String) = map[value]
+    fun fromValue(value: String) = map[value.toLowerNoSpace()]
+
+    private fun String.toLowerNoSpace() = toLowerCase().replace(" ", "")
   }
 }

--- a/komga/src/main/kotlin/org/gotson/komga/infrastructure/metadata/comicinfo/dto/AgeRating.kt
+++ b/komga/src/main/kotlin/org/gotson/komga/infrastructure/metadata/comicinfo/dto/AgeRating.kt
@@ -12,6 +12,7 @@ enum class AgeRating(val value: String, val ageRating: Int? = null) {
   KIDS_TO_ADULTS("Kids to Adults", 6),
   M("M", 17),
   MA_15("MA 15+", 15),
+  MA_15_NOSPACE("MA15+", 15),
   MATURE_17("Mature 17+", 17),
   PG("PG", 8),
   R_18("R18+", 18),

--- a/komga/src/main/kotlin/org/gotson/komga/infrastructure/metadata/comicinfo/dto/ComicInfo.kt
+++ b/komga/src/main/kotlin/org/gotson/komga/infrastructure/metadata/comicinfo/dto/ComicInfo.kt
@@ -43,6 +43,9 @@ class ComicInfo {
   @JsonProperty(value = "Month")
   var month: Int? = null
 
+  @JsonProperty(value = "Day")
+  var day: Int? = null
+
   @JsonProperty(value = "Writer")
   var writer: String? = null
 

--- a/komga/src/test/kotlin/org/gotson/komga/infrastructure/metadata/comicinfo/dto/ComicInfoTest.kt
+++ b/komga/src/test/kotlin/org/gotson/komga/infrastructure/metadata/comicinfo/dto/ComicInfoTest.kt
@@ -33,6 +33,34 @@ class ComicInfoTest {
   }
 
   @Test
+  fun `given another valid xml file when deserializing then properties are available`() {
+    val file = ClassPathResource("comicinfo/ComicInfo2.xml")
+    val mapper = XmlMapper()
+    val comicInfo = mapper.readValue(file.url, ComicInfo::class.java)
+
+    with(comicInfo) {
+      assertThat(title).isEqualTo("v01 - Preludes & Nocturnes - 30th Anniversary Edition")
+      assertThat(series).isEqualTo("Sandman")
+      assertThat(web).isEqualTo("https://www.comixology.com/Sandman/digital-comic/727888")
+      assertThat(summary).startsWith("Neil Gaiman's seminal series")
+      assertThat(notes).isEqualTo("Scraped metadata from Comixology [CMXDB727888], [RELDATE:2018-10-30]")
+      assertThat(publisher).isEqualTo("DC")
+      assertThat(imprint).isEqualTo("Vertigo")
+      assertThat(genre).isEqualTo("Fantasy, Supernatural/Occult, Horror, Mature, Superhero, Mythology, Drama")
+      assertThat(pageCount).isEqualTo(237)
+      assertThat(languageISO).isEqualTo("en")
+      assertThat(scanInformation).isEqualTo("")
+      assertThat(ageRating).isEqualTo(AgeRating.MA_15)
+      assertThat(blackAndWhite).isEqualTo(YesNo.NO)
+      assertThat(manga).isEqualTo(Manga.NO)
+      assertThat(seriesGroup).isEqualTo("Sandman")
+      assertThat(year).isEqualTo(2018)
+      assertThat(month).isEqualTo(10)
+      assertThat(day).isEqualTo(30)
+    }
+  }
+
+  @Test
   fun `given incorrect enum values when deserializing then it is ignored`() {
     val file = ClassPathResource("comicinfo/InvalidEnumValues.xml")
     val mapper = XmlMapper()

--- a/komga/src/test/resources/comicinfo/ComicInfo2.xml
+++ b/komga/src/test/resources/comicinfo/ComicInfo2.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<ComicInfo>
+    <Title>v01 - Preludes &amp; Nocturnes - 30th Anniversary Edition</Title>
+    <Series>Sandman</Series>
+    <Web>https://www.comixology.com/Sandman/digital-comic/727888</Web>
+    <Summary>Neil Gaiman's seminal series, THE SANDMAN, celebrates its 30th anniversary with an all-new edition of THE
+        SANDMAN VOL. 1: PRELUDES &amp; NOCTURNES!
+
+         New York Times best-selling author Neil Gaiman's transcendent series THE SANDMAN is often hailed as the
+        definitive Vertigo title and one of the finest achievements in graphic storytelling. Gaiman created an
+        unforgettable tale of the forces that exist beyond life and death by weaving ancient mythology, folklore and
+        fairy tales with his own distinct narrative vision.
+
+         In PRELUDES &amp; NOCTURNES, an occultist attempting to capture Death to bargain for eternal life traps her
+        younger brother Dream instead. After his 70 year imprisonment and eventual escape, Dream, also known as
+        Morpheus, goes on a quest for his lost objects of power. On his arduous journey Morpheus encounters Lucifer,
+        John Constantine, and an all-powerful madman.
+
+         This book also includes the story "The Sound of Her Wings," which introduces us to the pragmatic and perky goth
+        girl Death.
+
+         Collects THE SANDMAN #1-8.
+    </Summary>
+    <Notes>Scraped metadata from Comixology [CMXDB727888], [RELDATE:2018-10-30]</Notes>
+    <Publisher>DC</Publisher>
+    <Imprint>Vertigo</Imprint>
+    <Genre>Fantasy, Supernatural/Occult, Horror, Mature, Superhero, Mythology, Drama</Genre>
+    <PageCount>237</PageCount>
+    <LanguageISO>en</LanguageISO>
+    <AgeRating>MA15+</AgeRating>
+    <BlackAndWhite>No</BlackAndWhite>
+    <Year>2018</Year>
+    <Month>10</Month>
+    <Day>30</Day>
+    <Manga>No</Manga>
+    <SeriesGroup>Sandman</SeriesGroup>
+    <ScanInformation></ScanInformation>
+</ComicInfo>


### PR DESCRIPTION
[ComicTagger](https://github.com/comictagger/comictagger) uses the `Day` tag for the publishing day, and "MA15+" instead of "MA 15+" for the age rating, which Komga currently ignores.