### PR TITLE
fix(webui): compute scrollability on mount, fix right chevron when using display scaling

### DIFF
--- a/komga-webui/src/components/HorizontalScroller.vue
+++ b/komga-webui/src/components/HorizontalScroller.vue
@@ -44,19 +44,20 @@ export default Vue.extend({
   },
   mounted () {
     this.container = this.$refs[this.id] as HTMLElement
+    this.computeScrollability()
   },
   methods: {
     computeScrollability () {
       if (this.container !== undefined) {
-        this.canScrollLeft = this.container.scrollLeft > 0
-        this.canScrollRight = (this.container.scrollLeft + this.container.clientWidth) < this.container.scrollWidth
+        this.canScrollLeft = Math.round(this.container.scrollLeft) > 0
+        this.canScrollRight = (Math.round(this.container.scrollLeft) + this.container.clientWidth) < this.container.scrollWidth
       }
     },
     doScroll (direction: string) {
       if (this.container !== undefined) {
-        let target = this.container.scrollLeft + (this.container.clientWidth - this.adjustment)
+        let target = Math.round(this.container.scrollLeft) + (this.container.clientWidth - this.adjustment)
         if (direction === 'left') {
-          target = this.container.scrollLeft - (this.container.clientWidth - this.adjustment)
+          target = Math.round(this.container.scrollLeft) - (this.container.clientWidth - this.adjustment)
         }
         const scrollMax = this.container.clientWidth
         this.container.scrollTo({


### PR DESCRIPTION
Fix 1: Computing the scrollability on mount makes sure that the right chevron is not clickable when it's not possible to scroll after page load.

Fix 2: `container.scrollLeft` may return a decimal value on systems using display scaling. I discovered this issue while scrolling through Komga on my work laptop (using 125%). By rounding the value the `canScrollRight` equation will always return false if the div was already scrolled to the rightmost position. 