### PR TITLE
fix(api): support accept header in getBookPage

### DIFF
--- a/komga/src/main/kotlin/org/gotson/komga/interfaces/rest/BookController.kt
+++ b/komga/src/main/kotlin/org/gotson/komga/interfaces/rest/BookController.kt
@@ -298,7 +298,7 @@ class BookController(
   @GetMapping(value = [
     "api/v1/books/{bookId}/pages/{pageNumber}",
     "opds/v1.2/books/{bookId}/pages/{pageNumber}"
-  ], produces = ["image/*"])
+  ], produces = [MediaType.ALL_VALUE])
   @PreAuthorize("hasRole('$ROLE_PAGE_STREAMING')")
   fun getBookPage(
     @AuthenticationPrincipal principal: KomgaPrincipal,

--- a/komga/src/main/kotlin/org/gotson/komga/interfaces/rest/BookController.kt
+++ b/komga/src/main/kotlin/org/gotson/komga/interfaces/rest/BookController.kt
@@ -298,7 +298,7 @@ class BookController(
   @GetMapping(value = [
     "api/v1/books/{bookId}/pages/{pageNumber}",
     "opds/v1.2/books/{bookId}/pages/{pageNumber}"
-  ])
+  ], produces = ["image/*"])
   @PreAuthorize("hasRole('$ROLE_PAGE_STREAMING')")
   fun getBookPage(
     @AuthenticationPrincipal principal: KomgaPrincipal,


### PR DESCRIPTION
API is documented as supporting `accept: image/*` in the HTTP request,
but doing so results in server response with the status 406.

This commit updates the `GetMapping` annotation to correctly support
these values in the HTTP `accept` header.

As said in the issue, this fix currently the following test: `BookControllerTest > HttpCache > given request with If-Modified-Since headers when getting page then returns 304 not modified()`

closes #350