### PR TITLE
fix(webui) Only show the vertical scrollbar when required.

### DIFF
--- a/komga-webui/src/styles/global.css
+++ b/komga-webui/src/styles/global.css
@@ -1,3 +1,7 @@
+html {
+    overflow-y: auto !important;
+}
+
 .link-underline {
     text-decoration: none;
 }


### PR DESCRIPTION
This PR solves the problem with the vertical scrollbar always showing.  As per my comment on the ticket,

This is the expected behavior of the Vuetify package that normalizes the display.  However this particular behaviour is hotly debated ( [See here](https://vuetifyjs.com/en/getting-started/frequently-asked-questions/#scrollbar-overflow) ) but i agree it would be nice to have it only show when needed as that is what users have come to expect these days.

Tested this across Chrome and Firefox with a variety of screen sizes and works as expected 