### PR TITLE
feat(webui): Show the book title on search results the same as it appears on the book cards

### DIFF
--- a/komga-webui/src/components/SearchBox.vue
+++ b/komga-webui/src/components/SearchBox.vue
@@ -61,7 +61,7 @@
           </v-img>
 
           <v-list-item-content>
-            <v-list-item-title v-text="data.item.metadata.title"/>
+            <v-list-item-title v-text="bookTitle(data.item)"/>
           </v-list-item-content>
         </template>
 
@@ -196,6 +196,10 @@ export default Vue.extend({
       this.clear()
       this.$router.push({name: 'search', query: {q: s}}).catch(e => {
       })
+    },
+    bookTitle(book: BookDto): string {
+      const m = book.metadata
+      return `${m.number} - ${m.title}`
     },
     isUnread(book: BookDto): boolean {
       return getReadProgress(book) === ReadStatus.UNREAD


### PR DESCRIPTION
This will show the book titles in search results in the same way as it appears on the item cards.

`4 - foobar` instead of just `foobar` for example.