### PR TITLE
feat: added gray backround option to book reader

### DIFF
--- a/komga-webui/src/locales/en.json
+++ b/komga-webui/src/locales/en.json
@@ -105,7 +105,8 @@
       "background_color": "Background color",
       "background_colors": {
         "black": "Black",
-        "white": "White"
+        "white": "White",
+        "gray": "Gray"
       },
       "display": "Display",
       "general": "General",

--- a/komga-webui/src/views/BookReader.vue
+++ b/komga-webui/src/views/BookReader.vue
@@ -403,8 +403,8 @@ export default Vue.extend({
       })),
       backgroundColors: [
         {text: this.$t('bookreader.settings.background_colors.white').toString(), value: 'white'},
-        {text: this.$t('bookreader.settings.background_colors.black').toString(), value: 'black'},
         {text: this.$t('bookreader.settings.background_colors.gray').toString(), value: '#212121'},
+        {text: this.$t('bookreader.settings.background_colors.black').toString(), value: 'black'},
       ],
     }
   },

--- a/komga-webui/src/views/BookReader.vue
+++ b/komga-webui/src/views/BookReader.vue
@@ -404,6 +404,7 @@ export default Vue.extend({
       backgroundColors: [
         {text: this.$t('bookreader.settings.background_colors.white').toString(), value: 'white'},
         {text: this.$t('bookreader.settings.background_colors.black').toString(), value: 'black'},
+        {text: this.$t('bookreader.settings.background_colors.gray').toString(), value: '#212121'},
       ],
     }
   },


### PR DESCRIPTION
This PR adds a gray option for the background of the webreader, instead of just black and white. It uses the gray color from the dark webui theme.