### PR TITLE
Fix PDDocument not getting closed before cache eviction

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -13,9 +13,7 @@ You will need:
 
 Komga's commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) standard. This enables automatic versioning, releases, and release notes generation.
 
-Commit messages are enforced using commit hooks ran on the developer's PC. To install the necessary tooling, you need to run `npm install` in the root folder of the project. This will install the necessary commit hooks. You must then run `npm install` again within the `komga-webui` folder to get the tools the commit hooks use.
-
-To commit changes, you must run `git commit` from within the `komga-webui` folder.
+Commit messages are enforced using commit hooks ran on the developer's PC. To install the necessary tooling, you need to run `npm install` in the root folder of the project. This will install the necessary commit hooks.
 
 ## Project organization
 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -13,7 +13,9 @@ You will need:
 
 Komga's commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) standard. This enables automatic versioning, releases, and release notes generation.
 
-Commit messages are enforced using commit hooks ran on the developer's PC. To install the necessary tooling, you need to run `npm install` in the root folder of the project. This will install the necessary commit hooks.
+Commit messages are enforced using commit hooks ran on the developer's PC. To install the necessary tooling, you need to run `npm install` in the root folder of the project. This will install the necessary commit hooks. You must then run `npm install` again within the `komga-webui` folder to get the tools the commit hooks use.
+
+To commit changes, you must run `git commit` from within the `komga-webui` folder.
 
 ## Project organization
 

--- a/komga/src/main/kotlin/org/gotson/komga/infrastructure/mediacontainer/PdfExtractor.kt
+++ b/komga/src/main/kotlin/org/gotson/komga/infrastructure/mediacontainer/PdfExtractor.kt
@@ -27,7 +27,7 @@ class PdfExtractor : MediaContainerExtractor {
   private val cache = Caffeine.newBuilder()
     .maximumSize(20)
     .expireAfterAccess(1, TimeUnit.MINUTES)
-    .removalListener { _: Path?, pdf: PDDocument?, _ -> pdf?.close() }
+    .evictionListener { _: Path?, pdf: PDDocument?, _ -> pdf?.close() }
     .build<Path, PDDocument>()
 
   override fun mediaTypes(): List<String> = listOf("application/pdf")

--- a/komga/src/main/kotlin/org/gotson/komga/infrastructure/mediacontainer/ZipExtractor.kt
+++ b/komga/src/main/kotlin/org/gotson/komga/infrastructure/mediacontainer/ZipExtractor.kt
@@ -22,7 +22,7 @@ class ZipExtractor(
   private val cache = Caffeine.newBuilder()
     .maximumSize(20)
     .expireAfterAccess(1, TimeUnit.MINUTES)
-    .removalListener { _: Path?, zip: ZipFile?, _ -> zip?.close() }
+    .evictionListener { _: Path?, zip: ZipFile?, _ -> zip?.close() }
     .build<Path, ZipFile>()
 
   private val natSortComparator: Comparator<String> = CaseInsensitiveSimpleNaturalComparator.getInstance()


### PR DESCRIPTION
`removalListener` executes asynchronously (after eviction), but `evictionListener` executes synchronously during eviction, so the object can still be acted on and closed properly.

https://github.com/ben-manes/caffeine/wiki/Removal
https://www.javadoc.io/doc/com.github.ben-manes.caffeine/caffeine/latest/com.github.benmanes.caffeine/com/github/benmanes/caffeine/cache/Caffeine.html#evictionListener(com.github.benmanes.caffeine.cache.RemovalListener)

In addition, fixed some wording in the dev document to save someone else the frustration of wondering why it seemed a package was missing while committing