### PR TITLE
fix(webui): show the full title of book/series on hover in cards

### DIFF
--- a/komga-webui/src/components/ItemCard.vue
+++ b/komga-webui/src/components/ItemCard.vue
@@ -106,6 +106,7 @@
               v-line-clamp="2"
               v-bind="subtitleProps"
               v-html="title.title"
+              :title="title.title"
             />
           </router-link>
           <template v-if="Array.isArray(title)">
@@ -119,6 +120,7 @@
                 @click.native="$event.stopImmediatePropagation()"
                 class="link-underline text-truncate"
                 v-html="t.title"
+                :title="t.title"
                 style="display: block"
                 :class="i !== 0 ? 'font-weight-light' : ''"
               />


### PR DESCRIPTION
This adds the HTML title attribute on the book/series titles in the ItemCards, so that when you hover over it with the mouse, the full title will show in a popup. This helps with series with long titles that do not fit on the cards.

Fixes #836

Examples:
![image](https://user-images.githubusercontent.com/1193988/158605373-1c89cc90-9671-4610-a260-872fe8625d0e.png)

![image](https://user-images.githubusercontent.com/1193988/158605467-b660fff6-69a0-4250-b028-9fe48c32bd3c.png)
