### PR TITLE
feat(webui): set the currently viewed page as poster for book/series

### DIFF
--- a/komga-webui/src/functions/file.ts
+++ b/komga-webui/src/functions/file.ts
@@ -1,7 +1,7 @@
 import filesize from 'filesize'
 
-export async function getFileFromUrl(url: string, name: string = url, defaultType = 'image/jpeg') {
-  const response = await fetch(url)
+export async function getFileFromUrl(url: string, name: string = url, defaultType = 'image/jpeg', fetchOptions = {}) {
+  const response = await fetch(url, fetchOptions)
   const data = await response.blob()
   return new File([data], name, {
     type: data.type || defaultType,

--- a/komga-webui/src/functions/resize-image.ts
+++ b/komga-webui/src/functions/resize-image.ts
@@ -1,5 +1,5 @@
 function getCanvasBlob(canvas: HTMLCanvasElement): Promise<Blob | null> {
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve) => {
     canvas.toBlob((blob: Blob | null) => { resolve(blob) })
   })
 }

--- a/komga-webui/src/functions/resize-image.ts
+++ b/komga-webui/src/functions/resize-image.ts
@@ -1,0 +1,45 @@
+function getCanvasBlob(canvas: HTMLCanvasElement): Promise<Blob | null> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((blob: Blob | null) => { resolve(blob) })
+  })
+}
+
+export async function resizeImageFile(imageFile: File, maxWidth: number = 500, maxHeight: number = 500): Promise<File> {
+  const canvas = document.createElement('canvas')
+  const ctx = canvas.getContext('2d')
+  if (ctx !== null) {
+    const img = new Image()
+    img.src = URL.createObjectURL(imageFile)
+    await img.decode()
+
+    let width = img.width
+    let height = img.height
+
+    // Calculate width and height of the smaller image
+    if (width > height) {
+      if (width > maxWidth) {
+        height = height * (maxWidth / width)
+        width = maxWidth
+      }
+    } else {
+      if (height > maxHeight) {
+        width = width * (maxHeight / height)
+        height = maxHeight
+      }
+    }
+
+    canvas.width = width
+    canvas.height = height
+    // Release blob data to save browser memory
+    URL.revokeObjectURL(img.src)
+    ctx.drawImage(img, 0, 0, width, height)
+    const blob = await getCanvasBlob(canvas)
+    if (blob !== null) {
+      return new File([blob], 'poster', {lastModified: Date.now()})
+    }
+  }
+  // If we have not returned before here, resizing has failed for some reason.
+  // Maybe the browser doesn't support 2D canvas or image loading was not possible.
+  // Just return the original image.
+  return imageFile
+}

--- a/komga-webui/src/locales/en.json
+++ b/komga-webui/src/locales/en.json
@@ -79,7 +79,6 @@
   },
   "bookreader": {
     "beginning_of_book": "You're at the beginning of the book.",
-    "book_poster_set_to_current_page": "Book poster is now set to the current page.",
     "changing_reading_direction": "Changing Reading Direction to",
     "cycling_page_layout": "Cycling Page Layout",
     "cycling_scale": "Cycling Scale",
@@ -90,6 +89,9 @@
     "move_next": "Click or press \"Next\" again to move to the next book.",
     "move_next_exit": "Click or press \"Next\" again to exit the reader.",
     "move_previous": "Click or press \"Previous\" again to move to the previous book.",
+    "notification_poster_set_book": "Book poster is now set to the current page.",
+    "notification_poster_set_readlist": "Read list poster is now set to the current page.",
+    "notification_poster_set_series": "Series poster is now set to the current page.",
     "paged_reader_layout": {
       "double": "Double pages",
       "double_no_cover": "Double pages (no cover)",
@@ -105,8 +107,8 @@
       "width": "Fit width",
       "width_shrink_only": "Fit width (shrink only)"
     },
-    "series_poster_set_to_current_page": "Series poster is now set to the current page.",
     "set_current_page_as_book_poster": "Set page as poster for book",
+    "set_current_page_as_readlist_poster": "Set page as poster for read list",
     "set_current_page_as_series_poster": "Set page as poster for series",
     "settings": {
       "always_fullscreen": "Always Full Screen",

--- a/komga-webui/src/locales/en.json
+++ b/komga-webui/src/locales/en.json
@@ -79,6 +79,7 @@
   },
   "bookreader": {
     "beginning_of_book": "You're at the beginning of the book.",
+    "book_poster_set_to_current_page": "Book poster is now set to the current page.",
     "changing_reading_direction": "Changing Reading Direction to",
     "cycling_page_layout": "Cycling Page Layout",
     "cycling_scale": "Cycling Scale",
@@ -104,6 +105,9 @@
       "width": "Fit width",
       "width_shrink_only": "Fit width (shrink only)"
     },
+    "series_poster_set_to_current_page": "Series poster is now set to the current page.",
+    "set_current_page_as_book_poster": "Set page as poster for book",
+    "set_current_page_as_series_poster": "Set page as poster for series",
     "settings": {
       "always_fullscreen": "Always Full Screen",
       "animate_page_transitions": "Animate page transitions",

--- a/komga-webui/src/views/BookReader.vue
+++ b/komga-webui/src/views/BookReader.vue
@@ -63,11 +63,14 @@
               <v-list-item @click="downloadCurrentPage">
                 <v-list-item-title>{{ $t('bookreader.download_current_page') }}</v-list-item-title>
               </v-list-item>
-              <v-list-item @click="setCurrentPageAsBookPoster">
+              <v-list-item @click="setCurrentPageAsPoster(ItemTypes.BOOK)">
                 <v-list-item-title>{{ $t('bookreader.set_current_page_as_book_poster') }}</v-list-item-title>
               </v-list-item>
-              <v-list-item @click="setCurrentPageAsSeriesPoster">
+              <v-list-item @click="setCurrentPageAsPoster(ItemTypes.SERIES)">
                 <v-list-item-title>{{ $t('bookreader.set_current_page_as_series_poster') }}</v-list-item-title>
+              </v-list-item>
+              <v-list-item v-if="contextReadList"  @click="setCurrentPageAsPoster(ItemTypes.READLIST)">
+                <v-list-item-title>{{ $t('bookreader.set_current_page_as_readlist_poster') }}</v-list-item-title>
               </v-list-item>
             </v-list>
           </v-menu>
@@ -335,6 +338,7 @@ import {Context, ContextOrigin} from '@/types/context'
 import {SeriesDto} from '@/types/komga-series'
 import jsFileDownloader from 'js-file-downloader'
 import screenfull from 'screenfull'
+import {ItemTypes} from '@/types/items'
 
 export default Vue.extend({
   name: 'BookReader',
@@ -348,6 +352,7 @@ export default Vue.extend({
   },
   data: function () {
     return {
+      ItemTypes,
       screenfull,
       fullscreenIcon: 'mdi-fullscreen',
       book: {} as BookDto,
@@ -865,17 +870,23 @@ export default Vue.extend({
         forceDesktopMode: true,
       })
     },
-    async setCurrentPageAsBookPoster() {
-      let imageFile = await getFileFromUrl(this.currentPage.url, 'poster', 'image/jpeg', {credentials: 'include'})
-      let newImageFile = await resizeImageFile(imageFile)
-      await this.$komgaBooks.uploadThumbnail(this.book.id, newImageFile, true)
-      this.sendNotification(`${this.$t('bookreader.book_poster_set_to_current_page')}`)
-    },
-    async setCurrentPageAsSeriesPoster() {
-      let imageFile = await getFileFromUrl(this.currentPage.url, 'poster', 'image/jpeg', {credentials: 'include'})
-      let newImageFile = await resizeImageFile(imageFile)
-      await this.$komgaSeries.uploadThumbnail(this.series.id, newImageFile, true)
-      this.sendNotification(`${this.$t('bookreader.series_poster_set_to_current_page')}`)
+    async setCurrentPageAsPoster(type: ItemTypes) {
+      const imageFile = await getFileFromUrl(this.currentPage.url, 'poster', 'image/jpeg', {credentials: 'include'})
+      const newImageFile = await resizeImageFile(imageFile)
+      switch (type) {
+        case ItemTypes.BOOK:
+          await this.$komgaBooks.uploadThumbnail(this.book.id, newImageFile, true)
+          this.sendNotification(`${this.$t('bookreader.notification_poster_set_book')}`)
+          break
+        case ItemTypes.SERIES:
+          await this.$komgaSeries.uploadThumbnail(this.series.id, newImageFile, true)
+          this.sendNotification(`${this.$t('bookreader.notification_poster_set_series')}`)
+          break
+        case ItemTypes.READLIST:
+          await this.$komgaReadLists.uploadThumbnail(this.context.id, newImageFile, true)
+          this.sendNotification(`${this.$t('bookreader.notification_poster_set_readlist')}`)
+          break
+      }
     },
   },
 })

--- a/komga-webui/src/views/BookReader.vue
+++ b/komga-webui/src/views/BookReader.vue
@@ -314,6 +314,7 @@ import {getBookTitleCompact} from '@/functions/book-title'
 import {checkImageSupport, ImageFeature} from '@/functions/check-image'
 import {bookPageUrl} from '@/functions/urls'
 import {getFileFromUrl} from '@/functions/file'
+import {resizeImageFile} from '@/functions/resize-image'
 import {ReadingDirection} from '@/types/enum-books'
 import Vue from 'vue'
 import {Location} from 'vue-router'
@@ -866,61 +867,15 @@ export default Vue.extend({
     },
     async setCurrentPageAsBookPoster() {
       let imageFile = await getFileFromUrl(this.currentPage.url, 'poster', 'image/jpeg', {credentials: 'include'})
-      this.resizeImageForPoster(imageFile, async (newImageFile: File) => {
-        await this.$komgaBooks.uploadThumbnail(this.book.id, newImageFile, true)
-        this.sendNotification(`${this.$t('bookreader.book_poster_set_to_current_page')}`)
-      })
+      let newImageFile = await resizeImageFile(imageFile)
+      await this.$komgaBooks.uploadThumbnail(this.book.id, newImageFile, true)
+      this.sendNotification(`${this.$t('bookreader.book_poster_set_to_current_page')}`)
     },
     async setCurrentPageAsSeriesPoster() {
       let imageFile = await getFileFromUrl(this.currentPage.url, 'poster', 'image/jpeg', {credentials: 'include'})
-      this.resizeImageForPoster(imageFile, async (newImageFile: File) => {
-        await this.$komgaSeries.uploadThumbnail(this.series.id, newImageFile, true)
-        this.sendNotification(`${this.$t('bookreader.series_poster_set_to_current_page')}`)
-      })
-    },
-    resizeImageForPoster(imageFile: File, uploadCallback: (newImageFile: File) => void) {
-      const canvas = document.createElement('canvas')
-      const ctx = canvas.getContext('2d')
-      if (ctx !== null) {
-        const img = new Image()
-        img.onload = (event) => {
-            var MAX_WIDTH = 500
-            var MAX_HEIGHT = 500
-            var width = img.width
-            var height = img.height
-
-            // Calculate width and height of the smaller image
-            if (width > height) {
-                if (width > MAX_WIDTH) {
-                    height = height * (MAX_WIDTH / width)
-                    width = MAX_WIDTH
-                }
-            } else {
-                if (height > MAX_HEIGHT) {
-                    width = width * (MAX_HEIGHT / height)
-                    height = MAX_HEIGHT
-                }
-            }
-
-            canvas.width = width
-            canvas.height = height
-            // Release blob data to save browser memory
-            URL.revokeObjectURL(img.src)
-            ctx.drawImage(img, 0, 0, width, height)
-            canvas.toBlob((blob) => {
-              if (blob !== null) {
-                uploadCallback(new File([blob], 'poster', {lastModified: Date.now()}))
-              } else {
-                // Resizing failed for some reason, just try with original image.
-                uploadCallback(imageFile)
-              }
-            })
-        }
-        img.src = URL.createObjectURL(imageFile)
-      } else {
-        // Browser does not support 2D canvas, just try with original image.
-        uploadCallback(imageFile)
-      }
+      let newImageFile = await resizeImageFile(imageFile)
+      await this.$komgaSeries.uploadThumbnail(this.series.id, newImageFile, true)
+      this.sendNotification(`${this.$t('bookreader.series_poster_set_to_current_page')}`)
     },
   },
 })


### PR DESCRIPTION
This adds two buttons to the overflow menu of the reader to set the current page as the poster for either the book or series. To avoid large posters, it will also try to resize the image to max. 500x500 pixels before setting it as the poster.

Fixes #838 

Example of the buttons:
![image](https://user-images.githubusercontent.com/1193988/162258924-4bd50469-f7b3-42ca-b5c6-a695e3dcab50.png)

Hopefully the code quality is good enough, my TypeScript knowledge is not very good! Otherwise I'd be glad to improve it if you have advice.