### PR TITLE
fix(webui): display release date without timezone adjustment

### DIFF
--- a/komga-webui/src/views/BrowseSeries.vue
+++ b/komga-webui/src/views/BrowseSeries.vue
@@ -112,7 +112,7 @@
                 <v-tooltip right>
                   <template v-slot:activator="{ on }">
                   <span v-on="on">{{
-                      new Intl.DateTimeFormat($i18n.locale, {year: 'numeric'}).format(new Date(series.booksMetadata.releaseDate))
+                      new Intl.DateTimeFormat($i18n.locale, {year: 'numeric', timeZone: 'UTC'}).format(new Date(series.booksMetadata.releaseDate))
                     }}</span>
                   </template>
                   {{ $t('browse_series.earliest_year_from_release_dates') }}


### PR DESCRIPTION
this is the same fix as d343740f3021686bae9a41fd73c2102a51239faa, but applied to the series view instead of an individual book.

if the first issue of a series was released on January 1 applying a negative timezone offset will display the previous year.