### PR TITLE
fix: content length header for book downloads

### DIFF
--- a/komga/src/main/kotlin/org/gotson/komga/infrastructure/web/EtagFilterConfiguration.kt
+++ b/komga/src/main/kotlin/org/gotson/komga/infrastructure/web/EtagFilterConfiguration.kt
@@ -12,10 +12,10 @@ import javax.servlet.http.HttpServletRequest
 class EtagFilterConfiguration {
 
   private val excludePatterns = listOf(
-    PathPatternParser.defaultInstance.parse("/api/v1/books/{id}/file/**"),
-    PathPatternParser.defaultInstance.parse("/opds/v1.2/books/{id}/file/**"),
-    PathPatternParser.defaultInstance.parse("/api/v1/readlists/{id}/file/**"),
-    PathPatternParser.defaultInstance.parse("/api/v1/series/{id}/file/**"),
+    PathPatternParser.defaultInstance.parse("/api/v1/books/*/file/**"),
+    PathPatternParser.defaultInstance.parse("/opds/v1.2/books/*/file/**"),
+    PathPatternParser.defaultInstance.parse("/api/v1/readlists/*/file/**"),
+    PathPatternParser.defaultInstance.parse("/api/v1/series/*/file/**"),
   )
 
   @Bean

--- a/komga/src/main/kotlin/org/gotson/komga/infrastructure/web/EtagFilterConfiguration.kt
+++ b/komga/src/main/kotlin/org/gotson/komga/infrastructure/web/EtagFilterConfiguration.kt
@@ -3,18 +3,35 @@ package org.gotson.komga.infrastructure.web
 import org.springframework.boot.web.servlet.FilterRegistrationBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.server.PathContainer
 import org.springframework.web.filter.ShallowEtagHeaderFilter
+import org.springframework.web.util.pattern.PathPatternParser
+import javax.servlet.http.HttpServletRequest
 
 @Configuration
 class EtagFilterConfiguration {
+
+  private val excludePatterns = listOf(
+    PathPatternParser.defaultInstance.parse("/api/v1/books/{id}/file/**"),
+    PathPatternParser.defaultInstance.parse("/opds/v1.2/books/{id}/file/**"),
+    PathPatternParser.defaultInstance.parse("/api/v1/readlists/{id}/file/**"),
+    PathPatternParser.defaultInstance.parse("/api/v1/series/{id}/file/**"),
+  )
+
   @Bean
-  fun shallowEtagHeaderFilter(): FilterRegistrationBean<ShallowEtagHeaderFilter> =
-    FilterRegistrationBean(ShallowEtagHeaderFilter())
-      .also {
-        it.addUrlPatterns(
-          "/api/*",
-          "/opds/*",
-        )
-        it.setName("etagFilter")
-      }
+  fun shallowEtagHeaderFilter(): FilterRegistrationBean<out ShallowEtagHeaderFilter> =
+    FilterRegistrationBean(
+      object : ShallowEtagHeaderFilter() {
+        override fun shouldNotFilter(request: HttpServletRequest): Boolean {
+          val path = PathContainer.parsePath(request.servletPath)
+          return excludePatterns.any { it.matches(path) }
+        }
+      },
+    ).also {
+      it.addUrlPatterns(
+        "/api/*",
+        "/opds/*",
+      )
+      it.setName("etagFilter")
+    }
 }

--- a/komga/src/main/kotlin/org/gotson/komga/interfaces/api/rest/BookController.kt
+++ b/komga/src/main/kotlin/org/gotson/komga/interfaces/api/rest/BookController.kt
@@ -391,6 +391,7 @@ class BookController(
               },
             )
             .contentType(getMediaTypeOrDefault(media.mediaType))
+            .contentLength(this.contentLength())
             .body(stream)
         }
       } catch (ex: FileNotFoundException) {


### PR DESCRIPTION
- Disable ETag filter for file downloads
- Return content length header for book downloads
