### PR TITLE
fix: use zip64 for archive downloads

### DIFF
--- a/komga/src/main/kotlin/org/gotson/komga/interfaces/api/rest/ReadListController.kt
+++ b/komga/src/main/kotlin/org/gotson/komga/interfaces/api/rest/ReadListController.kt
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import mu.KotlinLogging
+import org.apache.commons.compress.archivers.zip.Zip64Mode
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry
 import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream
 import org.apache.commons.io.IOUtils
@@ -398,6 +399,7 @@ class ReadListController(
         ZipArchiveOutputStream(responseStream).use { zipStream ->
           zipStream.setMethod(ZipArchiveOutputStream.DEFLATED)
           zipStream.setLevel(Deflater.NO_COMPRESSION)
+          zipStream.setUseZip64(Zip64Mode.Always)
           books.forEach { (index, book) ->
             val file = FileSystemResource(book.path)
             if (!file.exists()) {

--- a/komga/src/main/kotlin/org/gotson/komga/interfaces/api/rest/SeriesController.kt
+++ b/komga/src/main/kotlin/org/gotson/komga/interfaces/api/rest/SeriesController.kt
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import mu.KotlinLogging
+import org.apache.commons.compress.archivers.zip.Zip64Mode
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry
 import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream
 import org.apache.commons.io.IOUtils
@@ -649,6 +650,7 @@ class SeriesController(
       ZipArchiveOutputStream(responseStream).use { zipStream ->
         zipStream.setMethod(ZipArchiveOutputStream.DEFLATED)
         zipStream.setLevel(Deflater.NO_COMPRESSION)
+        zipStream.setUseZip64(Zip64Mode.Always)
         books.forEach { book ->
           val file = FileSystemResource(book.path)
           if (!file.exists()) {


### PR DESCRIPTION
fixes an issue with series or read list archives that contain an entry over 4GB
At this point every archiver should support zip64 so it should be fine to always use it