### PR TITLE
Push container to GHCR & set source label on container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/ci/publish-dockerhub.sh
+++ b/ci/publish-dockerhub.sh
@@ -13,6 +13,9 @@ docker buildx build \
     --tag gotson/komga:$DOCKER_CHANNEL \
     --tag gotson/komga:$VERSION_MAJOR.x \
     --tag gotson/komga:$1 \
+    --tag ghcr.io/gotson/komga:$DOCKER_CHANNEL \
+    --tag ghcr.io/gotson/komga:$VERSION_MAJOR.x \
+    --tag ghcr.io/gotson/komga:$1 \
     --file ./Dockerfile . \
     --push
 
@@ -23,5 +26,8 @@ docker buildx build \
     --tag gotson/komga:$DOCKER_CHANNEL-legacy \
     --tag gotson/komga:$VERSION_MAJOR.x-legacy \
     --tag gotson/komga:$1-legacy \
+    --tag ghcr.io/gotson/komga:$DOCKER_CHANNEL-legacy \
+    --tag ghcr.io/gotson/komga:$VERSION_MAJOR.x-legacy \
+    --tag ghcr.io/gotson/komga:$1-legacy \
     --file ./Dockerfile.legacy . \
     --push

--- a/komga/Dockerfile
+++ b/komga/Dockerfile
@@ -10,3 +10,4 @@ ENV KOMGA_CONFIGDIR="/config"
 ENV LC_ALL=en_US.UTF-8
 ENTRYPOINT ["java", "org.springframework.boot.loader.JarLauncher", "--spring.config.additional-location=file:/config/"]
 EXPOSE 8080
+LABEL org.opencontainers.image.source="https://github.com/gotson/komga"

--- a/komga/Dockerfile.legacy
+++ b/komga/Dockerfile.legacy
@@ -10,3 +10,4 @@ ENV KOMGA_CONFIGDIR="/config"
 ENV LC_ALL=en_US.UTF-8
 ENTRYPOINT ["java", "org.springframework.boot.loader.JarLauncher", "--spring.config.additional-location=file:/config/"]
 EXPOSE 8080
+LABEL org.opencontainers.image.source="https://github.com/gotson/komga"


### PR DESCRIPTION
Some people prefer to pull containers from GHCR so I've setup the CI/CD to do that.

Whilst at it I added the source label to the containers so that tools like Renovate can find the source for release notes.

If you'd prefer this work as two seperate MRs & commits I'm happy to split them up.