### PR TITLE
remove default library access for oauth accounts

### DIFF
--- a/komga/src/main/kotlin/org/gotson/komga/infrastructure/security/oauth2/KomgaOAuth2UserServiceConfiguration.kt
+++ b/komga/src/main/kotlin/org/gotson/komga/infrastructure/security/oauth2/KomgaOAuth2UserServiceConfiguration.kt
@@ -68,6 +68,6 @@ class KomgaOAuth2UserServiceConfiguration(
   private fun tryCreateNewUser(email: String) =
     if (komgaProperties.oauth2AccountCreation) {
       logger.info { "Creating new user from OAuth2 login: $email" }
-      userLifecycle.createUser(KomgaUser(email, RandomStringUtils.randomAlphanumeric(12), roleAdmin = false))
+      userLifecycle.createUser(KomgaUser(email, RandomStringUtils.randomAlphanumeric(12), roleAdmin = false, sharedAllLibraries = false))
     } else throw OAuth2AuthenticationException("ERR_1025")
 }


### PR DESCRIPTION
This is just a suggestion, but i was expecting a newly created account via oauth2 would not have access to anything without an administrator giving him access. 