### PR TITLE
feat(webui): prefill author selection when bulk editing books

### DIFF
--- a/komga-webui/src/components/dialogs/EditOneshotDialog.vue
+++ b/komga-webui/src/components/dialogs/EditOneshotDialog.vue
@@ -573,7 +573,7 @@ import {isMatch} from 'date-fns'
 import IsbnVerify from '@saekitominaga/isbn-verify'
 import {debounce} from 'lodash'
 import {authorRoles} from '@/types/author-roles'
-import {groupAuthorsByRole} from '@/functions/authors'
+import {buildManyAuthorsByRole, groupAuthorsByRole} from '@/functions/authors'
 
 const tags = require('language-tags')
 
@@ -644,6 +644,7 @@ export default Vue.extend({
       genresAvailable: [] as string[],
       tagsAvailable: [] as string[],
       sharingLabelsAvailable: [] as string[],
+      isMultiBookAuthorDirty: false, // workaround for author consistency in bulk mode
     }
   },
   props: {
@@ -880,10 +881,20 @@ export default Vue.extend({
         this.form.series.sharingLabelsLock = sharingLabelsLock.length > 1 ? false : sharingLabelsLock[0]
 
         this.form.book.links = []
-        this.form.book.authors = {}
+        this.form.book.authors = buildManyAuthorsByRole(oneshots.map(x => x.book))
+
+        let forceAuthorLock = false
+        for (const oneshot of oneshots) {
+          const bookAuthor = groupAuthorsByRole(oneshot.book.metadata.authors)
+          if (!this.$_.isEqual(bookAuthor, this.form.book.authors)) {
+            this.isMultiBookAuthorDirty = true
+            forceAuthorLock = true
+            break
+          }
+        }
 
         const authorsLock = this.$_.uniq(oneshots.map(x => x.book.metadata.authorsLock))
-        this.form.book.authorsLock = authorsLock.length > 1 ? false : authorsLock[0]
+        this.form.book.authorsLock = authorsLock.length > 1 ? false : authorsLock[0] || forceAuthorLock
       } else {
         this.form.series.genres = []
         this.form.series.sharingLabels = []
@@ -925,7 +936,7 @@ export default Vue.extend({
           tagsLock: this.form.book.tagsLock,
         }
 
-        if (this.$v.form?.book?.authors?.$dirty) {
+        if (this.$v.form?.book?.authors?.$dirty || this.isMultiBookAuthorDirty) {
           this.$_.merge(metadataBook, {
             authors: this.$_.keys(this.form.book.authors).flatMap((role: string) =>
               this.$_.get(this.form.book.authors, role).map((name: string) => ({name: name, role: role})),

--- a/komga-webui/src/functions/authors.ts
+++ b/komga-webui/src/functions/authors.ts
@@ -1,8 +1,26 @@
-import {groupBy, mapValues} from 'lodash'
-import {AuthorDto} from '@/types/komga-books'
+import {flatMap, groupBy, intersection, mapValues, reduce, uniq} from 'lodash'
+import {AuthorDto, BookDto} from '@/types/komga-books'
+
+type AuthorsByRole = {[role: string]: string[]}
 
 // return an object where keys are roles, and values are string[]
-export function groupAuthorsByRole (authors: AuthorDto[]): any {
+export function groupAuthorsByRole (authors: AuthorDto[]): AuthorsByRole {
   return mapValues(groupBy(authors, 'role'),
     authors => authors.map((author: AuthorDto) => author.name))
+}
+
+// create an object where keys are roles and values are arrays of authors
+// we're using intersection to only include authors that are present on all books of each roles
+export function buildManyAuthorsByRole(books: BookDto[]): AuthorsByRole {
+  const allAuthorsByRoles = books.map(book => groupAuthorsByRole(book.metadata.authors))
+  const roleKeys = uniq(flatMap(allAuthorsByRoles, Object.keys))
+  return reduce(roleKeys, (acc: {[key: string]: string[]}, key) => {
+    const values = allAuthorsByRoles.map(authorsByRole => authorsByRole[key] || [])
+    const intersect = intersection(...values.filter(arr => arr.length > 0))
+
+    if (intersect.length > 0) {
+      acc[key] = intersect
+    }
+    return acc
+  }, {})
 }


### PR DESCRIPTION
The current implementation is that if we select multiple books like this:
- One has some author added
- Another is empty, or some of them filled

It will keep the whole thing empty.

This PR should make the selection prefilled with what has been added.

https://user-images.githubusercontent.com/34302902/213866289-3260f26c-7f58-44f0-8d1c-6db980f6dc89.mp4

---

Some problems need addressing:
As an example, two books have the following filled in:
- Book 1: `Writer`, `Penciller`
- Book 2: (Same) `Writer`
    
~~Currently, the form will have `Writer` and `Penciller` prefilled. I don't know if you like this behaviour or prefer to leave the `Penciller` empty.~~

Changed to basically get the intersection of many books for each roles, so only authors that exist on multiple books will be prefilled on a roles.