### PR TITLE
fix(api): first unread cover should include in progress books

### DIFF
--- a/komga/src/main/kotlin/org/gotson/komga/infrastructure/jooq/main/BookDao.kt
+++ b/komga/src/main/kotlin/org/gotson/komga/infrastructure/jooq/main/BookDao.kt
@@ -190,7 +190,7 @@ class BookDao(
       .leftJoin(d).on(b.ID.eq(d.BOOK_ID))
       .leftJoin(r).on(b.ID.eq(r.BOOK_ID)).and(r.USER_ID.eq(userId).or(r.USER_ID.isNull))
       .where(b.SERIES_ID.eq(seriesId))
-      .and(r.COMPLETED.isNull)
+      .and(r.COMPLETED.isNull.or(r.COMPLETED.isFalse))
       .orderBy(d.NUMBER_SORT)
       .limit(1)
       .fetchOne(b.ID)


### PR DESCRIPTION
When I'm reading a volume from a series I expect the cover of the volume I'm currently reading to be shown in my library when I have the "first unread or X" setting on, rather than the *next* volume, after the one I'm currently reading.

I realize that the setting mentions "unread" so it might be a little confusing but I felt like adding yet another setting would be even more confusing and I personally have a hard time imagining when one would want to see the next volume cover but maybe I'm missing something out :)