### PR TITLE
[oauth2] support custom signing algorithms and PKCE for social login 

### DIFF
--- a/komga/src/main/kotlin/org/gotson/komga/infrastructure/configuration/KomgaSettingsProvider.kt
+++ b/komga/src/main/kotlin/org/gotson/komga/infrastructure/configuration/KomgaSettingsProvider.kt
@@ -5,6 +5,7 @@ import org.gotson.komga.application.tasks.TaskPoolSizeChangedEvent
 import org.gotson.komga.domain.model.ThumbnailSize
 import org.gotson.komga.infrastructure.jooq.main.ServerSettingsDao
 import org.springframework.context.ApplicationEventPublisher
+import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm
 import org.springframework.stereotype.Service
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
@@ -85,6 +86,22 @@ class KomgaSettingsProvider(
         serverSettingsDao.deleteSetting(Settings.SERVER_CONTEXT_PATH.name)
       field = value
     }
+
+  var oauth2PKCE: Boolean =
+    serverSettingsDao.getSettingByKey(Settings.OAUTH2_PKCE.name, Boolean::class.java) ?: true
+    set(value) {
+      serverSettingsDao.saveSetting(Settings.OAUTH2_PKCE.name, value)
+      field = value
+    }
+
+  var oauth2IdTokenSigningAlgorithm: SignatureAlgorithm =
+    serverSettingsDao.getSettingByKey(Settings.OAUTH2_ID_TOKEN_SIGNING_ALGORITHM.name, String::class.java)?.let {
+      SignatureAlgorithm.valueOf(it)
+    } ?: SignatureAlgorithm.ES256
+    set(value) {
+      serverSettingsDao.saveSetting(Settings.OAUTH2_ID_TOKEN_SIGNING_ALGORITHM.name, value.toString())
+      field = value
+    }
 }
 
 private enum class Settings {
@@ -96,4 +113,6 @@ private enum class Settings {
   TASK_POOL_SIZE,
   SERVER_PORT,
   SERVER_CONTEXT_PATH,
+  OAUTH2_PKCE,
+  OAUTH2_ID_TOKEN_SIGNING_ALGORITHM
 }


### PR DESCRIPTION
This pr would allow users to configure different oauth2 id_token signing algorithms
And prevent against worst consequences of accidental client-secret leakage using PKCE.

Please let me know if I should do the configuration stuff differently or if things (beans) are in the wrong place :)
Or if the defaults should stay pkce disabled and RS256 signing.

I currently tested these changes locally using `komga [bootRun] dev,localdb,noclaim,oauth2` and my [kanidm](https://github.com/kanidm/kanidm) instance configured as custom oauth2 client/provider.
I also tested with the github example, seems to also support ES256 and pkce.