### PR TITLE
docs: fix FAQ link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-1. **Before reporting a new issue, take a look at the [FAQ](https://komga.org/faq/), the [changelog](https://github.com/gotson/komga/blob/master/CHANGELOG.md) and the already opened [issues](https://github.com/gotson/komga/issues).**
+1. **Before reporting a new issue, take a look at the [FAQ](https://komga.org/docs/faq/), the [changelog](https://github.com/gotson/komga/blob/master/CHANGELOG.md) and the already opened [issues](https://github.com/gotson/komga/issues).**
 1. If you are unsure, ask here: [![Discord](https://img.shields.io/discord/678794935368941569?label=Discord)](https://discord.gg/TdRpkDu)
 1. **DO NOT** reply on existing issues to say _"+1"_ or _"I am interested in this"_.
 1. **DO** show your enthusiasm for an existing issue by adding a :+1: reaction on the first message in the discussion.


### PR DESCRIPTION
The FAQ link is broken currently. This pull request simply changes the URL from https://komga.org/faq/ to https://komga.org/docs/faq/ 