### PR TITLE
Add progress marker toggle in EPUB reader

### DIFF
--- a/komga-webui/src/locales/en.json
+++ b/komga-webui/src/locales/en.json
@@ -781,7 +781,8 @@
         "click": "Click / Tap"
       },
       "page_margins": "Page margins",
-      "viewing_theme": "Viewing theme"
+      "viewing_theme": "Viewing theme",
+      "progress_markers": "Progress markers"
     },
     "shortcuts": {
       "cycle_pagination": "Cycle column count",

--- a/komga-webui/src/views/EpubReader.vue
+++ b/komga-webui/src/views/EpubReader.vue
@@ -164,12 +164,15 @@
                  v-if="!verticalScroll"
     >
       <v-row>
-        <v-col cols="10" class="text-truncate">
+        <v-col cols="10" class="text-truncate" v-if="progressMarkers">
           {{ $t('epubreader.page_of', {page: progressionPage, count: progressionPageCount}) }}
-          ({{ progressionTitle || $t('epubreader.current_chapter') }})
+          ({{ progressionTitle || $t('epubreader.current_chapter')}})
+        </v-col>
+        <v-col cols="10" class="text-truncate" v-else-if="progressionTitle">
+          {{ progressionTitle || $t('epubreader.current_chapter') }}
         </v-col>
         <v-spacer/>
-        <v-col cols="auto">{{ progressionTotalPercentage }}</v-col>
+        <v-col cols="auto" v-if="progressMarkers">{{ progressionTotalPercentage }}</v-col>
       </v-row>
     </v-container>
 
@@ -249,6 +252,9 @@
               <v-btn-toggle mandatory v-model="columnCount" class="py-3">
                 <v-btn v-for="(c, i) in columnCounts" :key="i" :value="c.value">{{ c.text }}</v-btn>
               </v-btn-toggle>
+            </v-list-item>
+            <v-list-item>
+              <settings-switch v-model="progressMarkers" :label="$t('epubreader.settings.progress_markers')"/>
             </v-list-item>
 
             <v-list-item class="justify-center">
@@ -412,6 +418,7 @@ export default Vue.extend({
         alwaysFullscreen: false,
         navigationClick: true,
         navigationButtons: true,
+        progressMarkers: true,
       },
       navigationOptions: [
         {text: this.$t('epubreader.settings.navigation_options.buttons').toString(), value: 'button'},
@@ -615,6 +622,15 @@ export default Vue.extend({
         this.$store.commit('setWebreaderAlwaysFullscreen', alwaysFullscreen)
         if (alwaysFullscreen) this.enterFullscreen()
         else screenfull.isEnabled && screenfull.exit()
+      },
+    },
+    progressMarkers: {
+      get: function (): boolean {
+        return this.settings.progressMarkers
+      },
+      set: function (value: boolean): void {
+        this.settings.progressMarkers = value
+        this.$store.commit('setEpubreaderSettings', this.settings)
       },
     },
     navigationMode: {


### PR DESCRIPTION
This PR adds a toggle to hide/show the progress markers visible on the bottom of the viewer in EPUB files.
Settings post-change:
![image](https://github.com/user-attachments/assets/1cba58ac-6d94-49c7-ac0c-c2db27def1ef)
Page markers on (default, existing behaviour):
![image](https://github.com/user-attachments/assets/3e9cc92e-ad69-4ad3-849e-6c917dd3c4de)
Page markers off (current progressionTitle falsy):
![image](https://github.com/user-attachments/assets/50a7b1e9-ca4c-4f73-ae0d-2165004e2692)
Page markers off (current progressionTitle truthy):
![image](https://github.com/user-attachments/assets/b6477527-db43-4cc3-b4b1-a7fd074de0e7)
