### PR TITLE
Proxy Content-Type headers for kobo sync.

### DIFF
--- a/komga/src/main/kotlin/org/gotson/komga/infrastructure/kobo/KoboProxy.kt
+++ b/komga/src/main/kotlin/org/gotson/komga/infrastructure/kobo/KoboProxy.kt
@@ -50,6 +50,7 @@ class KoboProxy(
       HttpHeaders.USER_AGENT,
       HttpHeaders.ACCEPT,
       HttpHeaders.ACCEPT_LANGUAGE,
+      HttpHeaders.CONTENT_TYPE,
     )
 
   private val headersOutExclude =


### PR DESCRIPTION
Without the `Content-Type: application/json` header the `/v1/analytics/gettests` endpoint fails to process the post data and returns a HTTP 200 result with the payload `{"Result":"MissingAffiliateOrSerialNumber"}`. This causes manual syncs to fail with a "Please try again." error.

This change will allow the `Content-Type` header to be forwarded. Once the header is forwarded manual syncs work correctly.

Fixes #2074