### PR TITLE
fix(kobo): Prevent double URL encoding.

### DIFF
--- a/komga/src/main/kotlin/org/gotson/komga/infrastructure/kobo/KoboProxy.kt
+++ b/komga/src/main/kotlin/org/gotson/komga/infrastructure/kobo/KoboProxy.kt
@@ -18,6 +18,7 @@ import org.springframework.util.LinkedMultiValueMap
 import org.springframework.web.client.RestClient
 import org.springframework.web.client.toEntity
 import org.springframework.web.server.ResponseStatusException
+import org.springframework.web.util.DefaultUriBuilderFactory
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.toJavaDuration
 
@@ -29,18 +30,26 @@ class KoboProxy(
   private val komgaSyncTokenGenerator: KomgaSyncTokenGenerator,
   private val komgaSettingsProvider: KomgaSettingsProvider,
 ) {
-  private val koboApiClient =
-    RestClient
-      .builder()
-      .baseUrl("https://storeapi.kobo.com")
-      .requestFactory(
-        ClientHttpRequestFactoryBuilder.reactor().build(
-          ClientHttpRequestFactorySettings
-            .defaults()
-            .withReadTimeout(1.minutes.toJavaDuration())
-            .withConnectTimeout(1.minutes.toJavaDuration()),
-        ),
-      ).build()
+  private val koboApiClient: RestClient
+
+  init {
+    val uriBuilderFactory = DefaultUriBuilderFactory("https://storeapi.kobo.com")
+    uriBuilderFactory.setEncodingMode(DefaultUriBuilderFactory.EncodingMode.NONE)
+
+    koboApiClient =
+      RestClient
+        .builder()
+        .uriBuilderFactory(
+          uriBuilderFactory,
+        ).requestFactory(
+          ClientHttpRequestFactoryBuilder.reactor().build(
+            ClientHttpRequestFactorySettings
+              .defaults()
+              .withReadTimeout(1.minutes.toJavaDuration())
+              .withConnectTimeout(1.minutes.toJavaDuration()),
+          ),
+        ).build()
+  }
 
   private val pathRegex = """\/kobo\/[-\w]*(.*)""".toRegex()
 


### PR DESCRIPTION
This changes to koboApiClient's uriBuilderFactory to disable encoding allowing us to copy `request.queryString` verbatim to the request that will be sent to storeapi.kobo.com. 

A request like `curl 'https://komga/kobo/XXX/test?1=%26' now results in `Proxy URL: https://storeapi.kobo.com/test?1=%26` being logged.

Additionally when syncing the broken HTTP requests from #2063 are still sent correctly. This was confirmed by syncing I seeing requests like `Proxy URL: https://storeapi.kobo.com/v1/assets?DiffRequests=[%7BKey:KoboPlus-NeverSubscribed-Promotion-US,ETag:W/NjM4OTY3MzY2ODMwMDAwMDAwLTExMDA1MQ%3D%3D%7D]` in the logs. I am unable to get curl to generate malformed requests like this to test manually.

Fixes #2130