### PR TITLE
(kobo): Log error responses.

### DIFF
--- a/komga/src/main/kotlin/org/gotson/komga/infrastructure/kobo/KoboProxy.kt
+++ b/komga/src/main/kotlin/org/gotson/komga/infrastructure/kobo/KoboProxy.kt
@@ -120,6 +120,7 @@ class KoboProxy(
         }.apply { if (body != null) body(body) }
         .retrieve()
         .onStatus(HttpStatusCode::isError) { _, response ->
+          logger.debug { "Kobo response: $response" }
           throw ResponseStatusException(response.statusCode, response.statusText)
         }.toEntity<JsonNode>()
 


### PR DESCRIPTION
Currently only the results of successful requests to the kobo servers are logged. With this change the error results will also be logged. This would make debug logs like https://github.com/gotson/komga/issues/2074#issuecomment-3288080241 more useful. In this case we would have seen the HTTP 400 error logged with the body `{"Result":"MissingAffiliateOrSerialNumber"}` vs not seeing any result from the kobo servers.