### PR TITLE
feat(webui): add option to hide book number in title - Please ignore, closing

### DIFF
--- a/komga-webui/src/components/ItemCard.vue
+++ b/komga-webui/src/components/ItemCard.vue
@@ -281,6 +281,9 @@ export default Vue.extend({
     isBlurUnread(): boolean {
       return this.$store.getters.getClientSettings[CLIENT_SETTING.WEBUI_POSTER_BLUR_UNREAD]?.value === 'true'
     },
+    showBookNumber(): boolean {
+      return this.$store.getters.getClientSettings[CLIENT_SETTING.WEBUI_BOOK_TITLE_SHOW_NUMBER]?.value !== 'false'
+    },
     shouldBlurPoster(): boolean | undefined {
       return (this.isUnread || this.allUnread) && this.isBlurUnread
     },
@@ -303,7 +306,11 @@ export default Vue.extend({
       return this.computedItem.thumbnailUrl() + this.thumbnailCacheBust
     },
     title(): ItemTitle | ItemTitle[] {
-      return this.computedItem.title(this.itemContext)
+      const context = [...this.itemContext]
+      if (!this.showBookNumber) {
+        context.push(ItemContext.HIDE_NUMBER)
+      }
+      return this.computedItem.title(context)
     },
     subtitleProps(): Object {
       return this.computedItem.subtitleProps()

--- a/komga-webui/src/locales/en.json
+++ b/komga-webui/src/locales/en.json
@@ -1053,6 +1053,7 @@
     "label_oauth2_hide_login": "Hide login fields if OAuth2 is enabled",
     "label_poster_blur_unread": "Blur poster for unread books and series",
     "label_poster_stretch": "Stretch poster to fit card",
+    "label_book_title_show_number": "Show book number in title",
     "label_series_groups": "Series grouping",
     "section_oauth2": "OAuth2",
     "series_groups": {

--- a/komga-webui/src/locales/fr.json
+++ b/komga-webui/src/locales/fr.json
@@ -1053,6 +1053,7 @@
     "label_oauth2_hide_login": "Masquer le champs de login si OAuth2 est activé",
     "label_poster_blur_unread": "Flouter les couvertures des livres et séries non lus",
     "label_poster_stretch": "Étire la couverture",
+    "label_book_title_show_number": "Afficher le numéro dans le titre du livre",
     "label_series_groups": "Regroupement de séries",
     "section_oauth2": "OAuth2",
     "series_groups": {

--- a/komga-webui/src/types/items.ts
+++ b/komga-webui/src/types/items.ts
@@ -19,6 +19,7 @@ export enum ItemContext {
   FILE_SIZE = 'FILE_SIZE',
   SHOW_SERIES = 'SHOW_SERIES',
   READ_DATE = 'READ_DATE',
+  HIDE_NUMBER = 'HIDE_NUMBER',
 }
 
 export interface ItemTitle {
@@ -83,6 +84,10 @@ export class BookItem extends Item<BookDto> {
         title: this.item.metadata.title,
         to: this.to(),
       }
+    const hideNumber = context.includes(ItemContext.HIDE_NUMBER)
+    const bookTitle = hideNumber
+      ? this.item.metadata.title
+      : `${this.item.metadata.number} - ${this.item.metadata.title}`
     if (context.includes(ItemContext.SHOW_SERIES))
       return [
         {
@@ -90,12 +95,12 @@ export class BookItem extends Item<BookDto> {
           to: this.seriesTo(),
         },
         {
-          title: `${this.item.metadata.number} - ${this.item.metadata.title}`,
+          title: bookTitle,
           to: this.to(),
         },
       ]
     return {
-      title: `${this.item.metadata.number} - ${this.item.metadata.title}`,
+      title: bookTitle,
       to: this.to(),
     }
   }

--- a/komga-webui/src/types/komga-clientsettings.ts
+++ b/komga-webui/src/types/komga-clientsettings.ts
@@ -17,6 +17,7 @@ export enum CLIENT_SETTING {
   WEBUI_OAUTH2_AUTO_LOGIN = 'webui.oauth2.auto_login',
   WEBUI_POSTER_STRETCH = 'webui.poster.stretch',
   WEBUI_POSTER_BLUR_UNREAD = 'webui.poster.blur_unread',
+  WEBUI_BOOK_TITLE_SHOW_NUMBER = 'webui.book_title.show_number',
   WEBUI_LIBRARIES = 'webui.libraries',
   WEBUI_SERIES_GROUPS = 'webui.series_groups',
   WEBUI_RECOMMENDED = 'webui.recommended',

--- a/komga-webui/src/views/BrowseBook.vue
+++ b/komga-webui/src/views/BrowseBook.vue
@@ -71,7 +71,7 @@
                   {{ book.metadata.title }}
                 </template>
                 <template v-else-if="contextReadList && book.oneshot">{{ book.metadata.title }}</template>
-                <template v-else>{{ book.metadata.number }} - {{ book.metadata.title }}</template>
+                <template v-else>{{ showBookNumber ? book.metadata.number + ' - ' : '' }}{{ book.metadata.title }}</template>
               </v-list-item-title>
             </v-list-item>
           </v-list-item-group>
@@ -471,6 +471,7 @@ import {BookSseDto, LibrarySseDto, ReadListSseDto, ReadProgressSseDto} from '@/t
 import {RawLocation} from 'vue-router/types/router'
 import {ReadListDto} from '@/types/komga-readlists'
 import {BookSearch, SearchConditionSeriesId, SearchConditionTag, SearchOperatorIs} from '@/types/komga-search'
+import {CLIENT_SETTING} from '@/types/komga-clientsettings'
 
 export default Vue.extend({
   name: 'BrowseBook',
@@ -531,6 +532,9 @@ export default Vue.extend({
     },
     isAdmin(): boolean {
       return this.$store.getters.meAdmin
+    },
+    showBookNumber(): boolean {
+      return this.$store.getters.getClientSettings[CLIENT_SETTING.WEBUI_BOOK_TITLE_SHOW_NUMBER]?.value !== 'false'
     },
     unavailable(): boolean {
       return this.book.deleted || this.$store.getters.getLibraryById(this.book.libraryId).unavailable

--- a/komga-webui/src/views/BrowseOneshot.vue
+++ b/komga-webui/src/views/BrowseOneshot.vue
@@ -80,7 +80,7 @@
                     book.metadata.title
                   }}
                 </template>
-                <template v-else>{{ book.metadata.number }} - {{ book.metadata.title }}</template>
+                <template v-else>{{ showBookNumber ? book.metadata.number + ' - ' : '' }}{{ book.metadata.title }}</template>
               </v-list-item-title>
             </v-list-item>
           </v-list-item-group>
@@ -568,6 +568,7 @@ import {
 import {RawLocation} from 'vue-router/types/router'
 import {ReadListDto} from '@/types/komga-readlists'
 import {Oneshot, SeriesDto} from '@/types/komga-series'
+import {CLIENT_SETTING} from '@/types/komga-clientsettings'
 import CollectionsExpansionPanels from '@/components/CollectionsExpansionPanels.vue'
 import OneshotActionsMenu from '@/components/menus/OneshotActionsMenu.vue'
 import {
@@ -663,6 +664,9 @@ export default Vue.extend({
     },
     isAdmin(): boolean {
       return this.$store.getters.meAdmin
+    },
+    showBookNumber(): boolean {
+      return this.$store.getters.getClientSettings[CLIENT_SETTING.WEBUI_BOOK_TITLE_SHOW_NUMBER]?.value !== 'false'
     },
     unavailable(): boolean {
       return this.book.deleted || this.$store.getters.getLibraryById(this.book.libraryId).unavailable

--- a/komga-webui/src/views/UIUserSettings.vue
+++ b/komga-webui/src/views/UIUserSettings.vue
@@ -15,6 +15,13 @@
           :label="$t('ui_settings.label_poster_blur_unread')"
           hide-details
         />
+
+        <v-checkbox
+          v-model="form.bookTitleShowNumber"
+          @change="$v.form.bookTitleShowNumber.$touch()"
+          :label="$t('ui_settings.label_book_title_show_number')"
+          hide-details
+        />
       </v-col>
     </v-row>
     <v-row>
@@ -45,12 +52,14 @@ export default Vue.extend({
     form: {
       posterStretch: false,
       posterBlurUnread: false,
+      bookTitleShowNumber: true,
     },
   }),
   validations: {
     form: {
       posterStretch: {},
       posterBlurUnread: {},
+      bookTitleShowNumber: {},
     },
   },
   mounted() {
@@ -69,6 +78,7 @@ export default Vue.extend({
       await this.$store.dispatch('getClientSettingsUser')
       this.form.posterStretch = this.$store.state.komgaSettings.clientSettingsUser[CLIENT_SETTING.WEBUI_POSTER_STRETCH]?.value === 'true'
       this.form.posterBlurUnread = this.$store.state.komgaSettings.clientSettingsUser[CLIENT_SETTING.WEBUI_POSTER_BLUR_UNREAD]?.value === 'true'
+      this.form.bookTitleShowNumber = this.$store.state.komgaSettings.clientSettingsUser[CLIENT_SETTING.WEBUI_BOOK_TITLE_SHOW_NUMBER]?.value !== 'false'
       this.$v.form.$reset()
     },
     async saveSettings() {
@@ -81,6 +91,10 @@ export default Vue.extend({
       if (this.$v.form?.posterBlurUnread?.$dirty)
         newSettings[CLIENT_SETTING.WEBUI_POSTER_BLUR_UNREAD] = {
           value: this.form.posterBlurUnread ? 'true' : 'false',
+        }
+      if (this.$v.form?.bookTitleShowNumber?.$dirty)
+        newSettings[CLIENT_SETTING.WEBUI_BOOK_TITLE_SHOW_NUMBER] = {
+          value: this.form.bookTitleShowNumber ? 'true' : 'false',
         }
 
       await this.$komgaSettings.updateClientSettingUser(newSettings)


### PR DESCRIPTION
Add a new user setting "Show book number in title" that allows users to hide the number prefix (e.g., "1 - ") from book titles displayed in the UI. This is useful when all books in a series have the same number (like volume 1) set in their ComicInfo metadata.

The option is accessible in Settings > UI Settings and defaults to showing the number (current behavior).