### PR TITLE
fix: sibling next/prev ordering for duplicate numberSort

### DIFF
--- a/komga/src/main/kotlin/org/gotson/komga/infrastructure/jooq/main/BookDtoDao.kt
+++ b/komga/src/main/kotlin/org/gotson/komga/infrastructure/jooq/main/BookDtoDao.kt
@@ -323,11 +323,18 @@ class BookDtoDao(
     val seriesId = record.get(0, String::class.java)
     val numberSort = record.get(1, Float::class.java)
 
+    val orderBy =
+      if (next) {
+        listOf(d.NUMBER_SORT.asc(), b.ID.asc())
+      } else {
+        listOf(d.NUMBER_SORT.desc(), b.ID.desc())
+      }
+
     return dslRO
       .selectBase(userId)
       .where(b.SERIES_ID.eq(seriesId))
-      .orderBy(d.NUMBER_SORT.let { if (next) it.asc() else it.desc() })
-      .seek(numberSort)
+      .orderBy(orderBy)
+      .seek(numberSort, bookId)
       .limit(1)
       .fetchAndMap(dslRO)
       .firstOrNull()


### PR DESCRIPTION
## Backgound

`/api/v1/books/{bookId}/next` used only `number_sort` for ordering and keyset seek.
When multiple books shared the same `number_sort`, the next/previous book could be unstable and diverge from `On Deck` selection, which uses number_sort + book_id as a tie-breaker.

## Solution

`findSiblingSeries` ordered and seeked solely by number_sort, leaving ties without deterministic ordering.
Align sibling ordering with `On Deck` by adding `book_id` as a secondary sort key and seek parameter.
This keeps endpoint semantics while making ties stable.