### PR TITLE
Added filter persistence for the series view

### DIFF
--- a/komga-webui/src/plugins/persisted-state.ts
+++ b/komga-webui/src/plugins/persisted-state.ts
@@ -45,6 +45,11 @@ export const persistedModule: Module<any, any> = {
     importPath: '',
     duplicatesNewPageSize: 10,
     rememberMe: false,
+    seriesBooks: {
+      filter: {} as FiltersActive,
+      filterMode: {} as FiltersActiveMode,
+      sort: {} as SortActive,
+    },
   },
   getters: {
     getLocaleFirstDay: (state) => () => {
@@ -91,6 +96,15 @@ export const persistedModule: Module<any, any> = {
     },
     getLibraryRoute: (state) => (id: string) => {
       return state.library.route[id]
+    },
+    getSeriesBooksFilter: (state) => {
+      return state.seriesBooks.filter
+    },
+    getSeriesBooksFilterMode: (state) => {
+      return state.seriesBooks.filterMode
+    },
+    getSeriesBooksSort: (state) => {
+      return state.seriesBooks.sort
     },
   },
   mutations: {
@@ -174,6 +188,15 @@ export const persistedModule: Module<any, any> = {
     },
     setRememberMe(state, val) {
       state.rememberMe = val
+    },
+    setSeriesBooksFilter(state, filter) {
+      state.seriesBooks.filter = filter
+    },
+    setSeriesBooksFilterMode(state, filterMode) {
+      state.seriesBooks.filterMode = filterMode
+    },
+    setSeriesBooksSort(state, sort) {
+      state.seriesBooks.sort = sort
     },
   },
 }

--- a/komga-webui/src/views/BrowseSeries.vue
+++ b/komga-webui/src/views/BrowseSeries.vue
@@ -896,6 +896,8 @@ export default Vue.extend({
         authorRoles.forEach((role: string) => {
           activeFilters[role] = route.query[role] || []
         })
+      } else {
+        activeFilters = this.$store.getters.getSeriesBooksFilter
       }
       this.filters = this.validateFilters(activeFilters)
 
@@ -903,6 +905,8 @@ export default Vue.extend({
       let activeFiltersMode = {} as FiltersActiveMode
       if (route.query.filterMode) {
         activeFiltersMode = route.query.filterMode
+      } else {
+        activeFiltersMode = this.$store.getters.getSeriesBooksFilterMode
       }
       this.filtersMode = this.validateFiltersMode(activeFiltersMode)
     },
@@ -926,9 +930,18 @@ export default Vue.extend({
       return validFilterMode
     },
     setWatches() {
-      this.sortUnwatch = this.$watch('sortActive', this.updateRouteAndReload)
-      this.filterUnwatch = this.$watch('filters', this.updateRouteAndReload)
-      this.filterModeUnwatch = this.$watch('filtersMode', this.updateRouteAndReload)
+      this.sortUnwatch = this.$watch('sortActive', (val) => {
+        this.$store.commit('setSeriesBooksSort', val)
+        this.updateRouteAndReload()
+      })
+      this.filterUnwatch = this.$watch('filters', (val) => {
+        this.$store.commit('setSeriesBooksFilter', val)
+        this.updateRouteAndReload()
+      })
+      this.filterModeUnwatch = this.$watch('filtersMode', (val) => {
+        this.$store.commit('setSeriesBooksFilterMode', val)
+        this.updateRouteAndReload()
+      })
       this.pageSizeUnwatch = this.$watch('pageSize', (val) => {
         this.$store.commit('setBrowsingPageSize', val)
         this.updateRouteAndReload()
@@ -1016,7 +1029,8 @@ export default Vue.extend({
       await this.loadPage(seriesId, this.page, this.sortActive)
     },
     parseQuerySortOrDefault(querySort: any): SortActive {
-      return parseQuerySort(querySort, this.sortOptions) || this.$_.clone(this.sortDefault)
+      return parseQuerySort(querySort, this.sortOptions) ||
+        (this.$store.getters.getSeriesBooksSort?.key ? this.$store.getters.getSeriesBooksSort : this.$_.clone(this.sortDefault))
     },
     parseQueryFilterStatus(queryStatus: any): string[] {
       return queryStatus ? queryStatus.toString().split(',').filter((x: string) => Object.keys(ReadStatus).includes(x)) : []


### PR DESCRIPTION
Changes made for feature request #2220 

Allows for global persistence of filtering by storing the filter, filterMode, and sort settings in the browser's Local Storage.

Still allows for _URL Query Parameters_, but only retrieves from local storage when the user selects a different sorting method.

Example scenario:

1. User would open series A and set filtering to "Numbers" in descending order
2. User would exit series A and open series B
3. in series B, the "Numbers" filter (in the descending order) should have persisted 