### PR TITLE
build(docker): update base image to Ubuntu 26.04 for amd64 and arm64

### DIFF
--- a/komga/docker/Dockerfile.tpl
+++ b/komga/docker/Dockerfile.tpl
@@ -5,12 +5,11 @@ COPY assembly/${JAR} application.jar
 RUN java -Djarmode=tools -jar application.jar extract --layers --destination extracted
 
 # amd64 builder
-FROM ubuntu:24.10 AS build-amd64
+FROM ubuntu:26.04 AS build-amd64
 ENV JAVA_HOME=/opt/java/openjdk
 COPY --from=eclipse-temurin:23-jre $JAVA_HOME $JAVA_HOME
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
-RUN sed -i -re 's/([a-z]{2}\.)?archive.ubuntu.com|security.ubuntu.com/old-releases.ubuntu.com/g' /etc/apt/sources.list.d/ubuntu.sources && \
-    apt -y update && \
+RUN apt -y update && \
     apt -y install ca-certificates locales libjxl-dev libheif-dev libwebp-dev libarchive-dev wget curl && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
@@ -20,12 +19,11 @@ RUN sed -i -re 's/([a-z]{2}\.)?archive.ubuntu.com|security.ubuntu.com/old-releas
 ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/lib/x86_64-linux-gnu"
 
 # arm64 builder
-FROM ubuntu:24.10 AS build-arm64
+FROM ubuntu:26.04 AS build-arm64
 ENV JAVA_HOME=/opt/java/openjdk
 COPY --from=eclipse-temurin:23-jre $JAVA_HOME $JAVA_HOME
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
-RUN sed -i -re 's/([a-z]{2}\.)?ports.ubuntu.com\/ubuntu-ports/old-releases.ubuntu.com\/ubuntu/g' /etc/apt/sources.list.d/ubuntu.sources && \
-    apt -y update && \
+RUN apt -y update && \
     apt -y install ca-certificates locales libjxl-dev libheif-dev libwebp-dev libarchive-dev wget curl && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \


### PR DESCRIPTION
- Because of https://github.com/gotson/komga/issues/2021, the ubuntu base was downgrade to 24.10 which is now EOL and infested with CVEs.
- 25.10 never had libarchive bumped to a fixed version in ubuntu repos but it's EOL in upcoming july anyway.
- Ubuntu 26.04 LTS has libarchive at 3.8.5 and is expected to release in less than a month but is already available in dockerhub so we could use this time to test it.

I'm currently running my own built Komga based on 26.04 and seems okey so far