### PR TITLE
Fix serialization of KoboProxy objects

### DIFF
--- a/komga/src/main/kotlin/org/gotson/komga/infrastructure/kobo/KoboProxy.kt
+++ b/komga/src/main/kotlin/org/gotson/komga/infrastructure/kobo/KoboProxy.kt
@@ -113,7 +113,7 @@ class KoboProxy(
             }
           }
           logger.debug { "Headers out: $headersOut" }
-        }.apply { if (body != null) body(body) }
+        }.apply { if (body != null) body(objectMapper.writeValueAsBytes(body)) }
         .retrieve()
         .onStatus(HttpStatusCode::isError) { _, response ->
           logger.debug { "Kobo response: ${response.statusCode}: ${response.body.bufferedReader().use { it.readText() }}" }

--- a/komga/src/main/kotlin/org/gotson/komga/interfaces/api/kobo/KoboController.kt
+++ b/komga/src/main/kotlin/org/gotson/komga/interfaces/api/kobo/KoboController.kt
@@ -591,7 +591,10 @@ class KoboController(
               locations =
                 R2Locator.Location(
                   progression = koboUpdate.currentBookmark.contentSourceProgressPercent.toFloat() / 100,
-                  totalProgression = koboUpdate.currentBookmark.progressPercent?.toFloat()?.div(100),
+                  totalProgression =
+                    koboUpdate.currentBookmark.progressPercent
+                      ?.toFloat()
+                      ?.div(100),
                 ),
             )
           },

--- a/komga/src/main/kotlin/org/gotson/komga/interfaces/api/kobo/KoboController.kt
+++ b/komga/src/main/kotlin/org/gotson/komga/interfaces/api/kobo/KoboController.kt
@@ -590,8 +590,8 @@ class KoboController(
                   null,
               locations =
                 R2Locator.Location(
-                  progression = koboUpdate.currentBookmark.contentSourceProgressPercent / 100,
-                  totalProgression = koboUpdate.currentBookmark.progressPercent?.div(100),
+                  progression = koboUpdate.currentBookmark.contentSourceProgressPercent.toFloat() / 100,
+                  totalProgression = koboUpdate.currentBookmark.progressPercent?.toFloat()?.div(100),
                 ),
             )
           },

--- a/komga/src/main/kotlin/org/gotson/komga/interfaces/api/kobo/dto/BookmarkDto.kt
+++ b/komga/src/main/kotlin/org/gotson/komga/interfaces/api/kobo/dto/BookmarkDto.kt
@@ -1,5 +1,6 @@
 package org.gotson.komga.interfaces.api.kobo.dto
 
+import com.fasterxml.jackson.annotation.JsonFormat
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.PropertyNamingStrategies
 import com.fasterxml.jackson.databind.annotation.JsonNaming
@@ -8,16 +9,17 @@ import java.time.ZonedDateTime
 @JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy::class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class BookmarkDto(
+  @JsonFormat(shape = JsonFormat.Shape.STRING)
   val lastModified: ZonedDateTime,
   /**
    * Total progression in the book.
    * Between 0 and 100.
    */
-  val progressPercent: Float? = null,
+  val progressPercent: Int? = null,
   /**
    * Progression within the resource.
    * Between 0 and 100.
    */
-  val contentSourceProgressPercent: Float? = null,
+  val contentSourceProgressPercent: Int? = null,
   val location: LocationDto? = null,
 )

--- a/komga/src/main/kotlin/org/gotson/komga/interfaces/api/kobo/dto/LocationDto.kt
+++ b/komga/src/main/kotlin/org/gotson/komga/interfaces/api/kobo/dto/LocationDto.kt
@@ -1,9 +1,11 @@
 package org.gotson.komga.interfaces.api.kobo.dto
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.PropertyNamingStrategies
 import com.fasterxml.jackson.databind.annotation.JsonNaming
 
 @JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy::class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 data class LocationDto(
   /**
    * For type=KoboSpan values are in the form "kobo.x.y"

--- a/komga/src/main/kotlin/org/gotson/komga/interfaces/api/kobo/dto/ReadingStateDto.kt
+++ b/komga/src/main/kotlin/org/gotson/komga/interfaces/api/kobo/dto/ReadingStateDto.kt
@@ -1,5 +1,7 @@
 package org.gotson.komga.interfaces.api.kobo.dto
 
+import com.fasterxml.jackson.annotation.JsonFormat
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.PropertyNamingStrategies
 import com.fasterxml.jackson.databind.annotation.JsonNaming
 import org.gotson.komga.domain.model.ReadProgress
@@ -7,14 +9,18 @@ import org.gotson.komga.language.toUTCZoned
 import java.time.ZonedDateTime
 
 @JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy::class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 data class ReadingStateDto(
+  @JsonFormat(shape = JsonFormat.Shape.STRING)
   val created: ZonedDateTime? = null,
   val currentBookmark: BookmarkDto,
   val entitlementId: String,
+  @JsonFormat(shape = JsonFormat.Shape.STRING)
   val lastModified: ZonedDateTime,
   /**
    * From CW: apparently always equals to lastModified
    */
+  @JsonFormat(shape = JsonFormat.Shape.STRING)
   val priorityTimestamp: ZonedDateTime? = null,
   val statistics: StatisticsDto,
   val statusInfo: StatusInfoDto,
@@ -38,12 +44,14 @@ fun ReadProgress.toDto() =
           this.locator
             ?.locations
             ?.totalProgression
-            ?.times(100),
+            ?.times(100)
+            ?.toInt(),
         contentSourceProgressPercent =
           this.locator
             ?.locations
             ?.progression
-            ?.times(100),
+            ?.times(100)
+            ?.toInt(),
         location = this.locator?.let { LocationDto(source = it.href, value = it.koboSpan) },
       ),
     statistics =

--- a/komga/src/main/kotlin/org/gotson/komga/interfaces/api/kobo/dto/ReadingStateStateUpdateDto.kt
+++ b/komga/src/main/kotlin/org/gotson/komga/interfaces/api/kobo/dto/ReadingStateStateUpdateDto.kt
@@ -1,9 +1,11 @@
 package org.gotson.komga.interfaces.api.kobo.dto
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.PropertyNamingStrategies
 import com.fasterxml.jackson.databind.annotation.JsonNaming
 
 @JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy::class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 data class ReadingStateStateUpdateDto(
   val readingStates: Collection<ReadingStateDto> = emptyList(),
 )

--- a/komga/src/main/kotlin/org/gotson/komga/interfaces/api/kobo/dto/StatisticsDto.kt
+++ b/komga/src/main/kotlin/org/gotson/komga/interfaces/api/kobo/dto/StatisticsDto.kt
@@ -1,5 +1,6 @@
 package org.gotson.komga.interfaces.api.kobo.dto
 
+import com.fasterxml.jackson.annotation.JsonFormat
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.PropertyNamingStrategies
 import com.fasterxml.jackson.databind.annotation.JsonNaming
@@ -8,6 +9,7 @@ import java.time.ZonedDateTime
 @JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy::class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class StatisticsDto(
+  @JsonFormat(shape = JsonFormat.Shape.STRING)
   val lastModified: ZonedDateTime,
   val remainingTimeMinutes: Int? = null,
   val spentReadingMinutes: Int? = null,

--- a/komga/src/main/kotlin/org/gotson/komga/interfaces/api/kobo/dto/StatusInfoDto.kt
+++ b/komga/src/main/kotlin/org/gotson/komga/interfaces/api/kobo/dto/StatusInfoDto.kt
@@ -1,5 +1,6 @@
 package org.gotson.komga.interfaces.api.kobo.dto
 
+import com.fasterxml.jackson.annotation.JsonFormat
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.PropertyNamingStrategies
 import com.fasterxml.jackson.databind.annotation.JsonNaming
@@ -8,9 +9,12 @@ import java.time.ZonedDateTime
 @JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy::class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class StatusInfoDto(
+  @JsonFormat(shape = JsonFormat.Shape.STRING)
   val lastModified: ZonedDateTime,
   val status: StatusDto,
   val timesStartedReading: Int? = null,
+  @JsonFormat(shape = JsonFormat.Shape.STRING)
   val lastTimeFinished: ZonedDateTime? = null,
+  @JsonFormat(shape = JsonFormat.Shape.STRING)
   val lastTimeStartedReading: ZonedDateTime? = null,
 )


### PR DESCRIPTION
This pull request fixes #2289

It looks like the payload serialization is incorrect. While the request is properly deserialized into the Kotlin DTO by `KoboProxy`, it is not serialized back into the expected format, which results in a `400 BAD_REQUEST` response from the Kobo API.

```
Apr 16 03:23:34 helios64 env[60754]: 2026-04-16T03:23:34.807+09:00 DEBUG 60754 --- [io-32500-exec-8] o.g.komga.infrastructure.kobo.KoboProxy  : Kobo response: 400 BAD_REQUEST: {"ResponseStatus":{"ErrorCode":"BadRequest","Message":"Error handling 'ReadingStateRequest' request. Request.Id: 74aa7881-0534-45d4-a7c0","Errors":[]}}
```

From inspecting the traffic in Wireshark, I identified several fields that are incorrectly serialized by Jackson:

* Percentages are sent as floats instead of integers in
   * `ContentSourceProgressPercent`
   * `ProgressPercent`
* `null` fields from Komga are forwarded to the Kobo API, including
   * `Created`
   * `PriorityTimestamp`
* Dates are serialized as Unix timestamps instead of ISO 8601 strings for all fields labeled `LastModified`

This difference is only visible in the raw network traffic on Wireshark and does not appear in the application logs, which made the issue particularly difficult to diagnose using logs alone.

Moreover, some issues appears to be due to the Kobo API not supporting chunked encoding, so this needs to be disabled as well. Chunked request for PUT appears to result in a `400 BAD_REQUEST` as well.

## Resolution

1. Use `Int` instead of `Float` for percentage fields to match the expected API format.
2. Add `@JsonInclude(JsonInclude.Include.NON_NULL)` to prevent Komga specific `null` fields from being sent to the Kobo API.
3. Ensure dates are serialized as ISO 8601 strings by setting `@JsonFormat(shape = JsonFormat.Shape.STRING)`. Otherwise, Jackson’s `SerializationFeature.WRITE_DATES_AS_TIMESTAMPS` will apply and serialize dates as Unix timestamps.
4. Disable `transfer-encoding: chunked` but writing the full body in the request and get a `Content-Length` header. This eliminates all BAD_REQUEST due to empty request from chunked bodies i.e. `Kobo response: 400 BAD_REQUEST: {"Result":"EmptyRequest"}`
 
## Annex

This is a request sent by the kobo device
```
{
  "ReadingStates": [
    {
      "CurrentBookmark": {
        "ContentSourceProgressPercent": 8,
        "LastModified": "2026-04-16T11:13:48Z",
        "Location": {
          "Source": "OEBPS/PsychologyofMoney-14.xhtml",
          "Type": "KoboSpan",
          "Value": "kobo.1.1"
        },
        "ProgressPercent": 23
      },
      "EntitlementId": "f17a0811-4bc1-4131-8f60",
      "LastModified": "2026-04-16T11:13:48Z",
      "Statistics": {
        "LastModified": "2026-04-16T11:13:48Z",
        "RemainingTimeMinutes": 195,
        "SpentReadingMinutes": 945
      },
      "StatusInfo": {
        "LastModified": "2026-04-16T11:13:48Z",
        "Status": "Reading"
      }
    }
  ]
}
```

This is a request sent to the Kobo API after being handled by KoboProxy
```
{
  "ReadingStates": [
    {
      "Created": null,
      "CurrentBookmark": {
        "LastModified": 1776338028,
        "ProgressPercent": 23.0,
        "ContentSourceProgressPercent": 8.0,
        "Location": {
          "Value": "kobo.1.1",
          "Type": "KoboSpan",
          "Source": "OEBPS/PsychologyofMoney-14.xhtml"
        }
      },
      "EntitlementId": "f17a0811-4bc1-4131-8f60",
      "LastModified": 1776338028,
      "PriorityTimestamp": null,
      "Statistics": {
        "LastModified": 1776338028,
        "RemainingTimeMinutes": 195,
        "SpentReadingMinutes": 945
      },
      "StatusInfo": {
        "LastModified": 1776338028,
        "Status": "Reading"
      }
    }
  ]
}
```

As shown, dates are serialized as Unix timestamps by Jackson, and percentages are sent as floats instead of integers. This does not appear to align with the Kobo API expectations, which likely causes the `400 BAD_REQUEST` response.

After such a change you finally get the correct answer from the Kobo API

```
2026-04-16T22:10:54.748+09:00 DEBUG 52557 --- [nio-8080-exec-5] o.g.komga.infrastructure.kobo.KoboProxy  : Kobo response: <200 OK OK,{"RequestResult":"Success","UpdateResults":[{"EntitlementId":"f17a0811-4bc1-4131-8f60","StatusInfoResult":{"Result":"Success"},"StatisticsResult":{"Result":"Success"},"CurrentBookmarkResult":{"Result":"Success"}}]}
```

## How did I get there

### 1. Capturing the original request

I started by enabling debug output on the Kobo device (`sync`, `packetdump`, and `headerdump`), as described in the [Komga documentation](https://komga.org/docs/guides/kobo/), to see exactly what was being sent.

I noticed that the request updating a book’s reading progress is triggered when clicking **Back to Home** while reading. From there, I was able to reconstruct an equivalent curl request matching what the device sends to Komga.

### 2. Capturing the failing request from Komga

Next, I needed to inspect what Komga was sending to the Kobo API.

The existing logger only outputs headers, not the body, so I added [additional logging to capture the full request](https://github.com/gotson/komga/blob/master/komga/src/main/kotlin/org/gotson/komga/infrastructure/kobo/KoboProxy.kt#L116) payload. 

```
if (body != null) {
    logger.debug { "Body out: ${objectMapper.writeValueAsString(body)}" }
    body(body)
}
```

With that I was able to build both 

1. The OG request from the device to Komga
2. The failing proxied request from Komga to the Kobo API

This quickly revealed two issues:

* Integers were being serialized as floats
* Extra Komga specific fields were included in the payload

However, after fixing those, I still received 400 Bad Request responses from the Kobo API.

### 3. Wireshark to the rescue

At this point, I tried using Proxyman, but couldn’t get a proper MITM setup working with Java to inspect HTTPS traffic. So I switched to Wireshark and [temporarily downgraded the connection to plain HTTP](https://github.com/gotson/komga/blob/master/komga/src/main/kotlin/org/gotson/komga/infrastructure/kobo/KoboProxy.kt#L37) to inspect the raw requests.

That’s when the real issue surfaced. Jackson was serializing dates as Unix timestamps instead of ISO 8601 strings. And this wasn't showing in the logger output of KoboProxy. Once I forced Jackson to use the correct date format, the requests were finally accepted by the Kobo API.

It took me a full day of debugging, I'm exhausted 😮‍💨

## TL;DR

Eliminates all BAD_REQUESTS with errors
* `{"Result":"EmptyRequest"}`
* `{"ErrorCode":"BadRequest","Message":"Error handling 'ReadingStateRequest' request"}`
