### PR TITLE
feat(api): support HTTP Range requests on book file download endpoint

### DIFF
--- a/komga/src/main/kotlin/org/gotson/komga/interfaces/api/CommonBookController.kt
+++ b/komga/src/main/kotlin/org/gotson/komga/interfaces/api/CommonBookController.kt
@@ -32,6 +32,7 @@ import org.gotson.komga.interfaces.api.persistence.BookDtoRepository
 import org.springframework.core.io.FileSystemResource
 import org.springframework.http.ContentDisposition
 import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpRange
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
@@ -41,6 +42,7 @@ import org.springframework.util.MimeTypeUtils
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
@@ -328,37 +330,93 @@ class CommonBookController(
   fun downloadBookFile(
     @AuthenticationPrincipal principal: KomgaPrincipal,
     @PathVariable bookId: String,
-  ): ResponseEntity<StreamingResponseBody> = getBookFileInternal(principal, bookId)
+    @RequestHeader(HttpHeaders.RANGE, required = false) rangeHeader: String?,
+  ): ResponseEntity<StreamingResponseBody> = getBookFileInternal(principal, bookId, rangeHeader)
 
   fun getBookFileInternal(
     principal: KomgaPrincipal,
     bookId: String,
+    rangeHeader: String? = null,
   ): ResponseEntity<StreamingResponseBody> =
     bookRepository.findByIdOrNull(bookId)?.let { book ->
       contentRestrictionChecker.checkContentRestriction(principal.user, book)
       try {
         val media = mediaRepository.findById(book.id)
-        with(FileSystemResource(book.path)) {
-          if (!exists()) throw FileNotFoundException(path)
+        val resource = FileSystemResource(book.path)
+        if (!resource.exists()) throw FileNotFoundException(resource.path)
+        val fileLength = resource.contentLength()
+
+        val baseHeaders =
+          HttpHeaders().apply {
+            contentDisposition =
+              ContentDisposition
+                .builder("attachment")
+                .filename(book.path.name, StandardCharsets.UTF_8)
+                .build()
+            set(HttpHeaders.ACCEPT_RANGES, "bytes")
+          }
+
+        // Parse range — only honour a single range; fall back to full response for multi-range
+        val parsedRanges =
+          if (rangeHeader != null) {
+            try {
+              HttpRange.parseRanges(rangeHeader)
+            } catch (ex: IllegalArgumentException) {
+              return@let ResponseEntity
+                .status(HttpStatus.REQUESTED_RANGE_NOT_SATISFIABLE)
+                .headers(baseHeaders.apply { set(HttpHeaders.CONTENT_RANGE, "bytes */$fileLength") })
+                .build()
+            }
+          } else {
+            null
+          }
+
+        if (parsedRanges != null && parsedRanges.size == 1) {
+          val (start, end) =
+            try {
+              parsedRanges[0].getRangeStart(fileLength) to parsedRanges[0].getRangeEnd(fileLength)
+            } catch (ex: IllegalArgumentException) {
+              return@let ResponseEntity
+                .status(HttpStatus.REQUESTED_RANGE_NOT_SATISFIABLE)
+                .headers(baseHeaders.apply { set(HttpHeaders.CONTENT_RANGE, "bytes */$fileLength") })
+                .build()
+            }
+          val rangeLength = end - start + 1
           val stream =
             StreamingResponseBody { os: OutputStream ->
-              this.inputStream.use {
+              java.io.RandomAccessFile(resource.file, "r").use { raf ->
+                raf.seek(start)
+                val buffer = ByteArray(8192)
+                var remaining = rangeLength
+                while (remaining > 0) {
+                  val toRead = minOf(buffer.size.toLong(), remaining).toInt()
+                  val read = raf.read(buffer, 0, toRead)
+                  if (read == -1) break
+                  os.write(buffer, 0, read)
+                  remaining -= read
+                }
+              }
+            }
+          ResponseEntity
+            .status(HttpStatus.PARTIAL_CONTENT)
+            .headers(baseHeaders.apply { set(HttpHeaders.CONTENT_RANGE, "bytes $start-$end/$fileLength") })
+            .contentType(getMediaTypeOrDefault(media.mediaType))
+            .contentLength(rangeLength)
+            .body(stream)
+        } else {
+          // No range header or multi-range: stream the full file
+          val stream =
+            StreamingResponseBody { os: OutputStream ->
+              resource.inputStream.use {
                 IOUtils.copyLarge(it, os, ByteArray(8192))
                 os.close()
               }
             }
           ResponseEntity
             .ok()
-            .headers(
-              HttpHeaders().apply {
-                contentDisposition =
-                  ContentDisposition
-                    .builder("attachment")
-                    .filename(book.path.name, StandardCharsets.UTF_8)
-                    .build()
-              },
-            ).contentType(getMediaTypeOrDefault(media.mediaType))
-            .contentLength(this.contentLength())
+            .headers(baseHeaders)
+            .contentType(getMediaTypeOrDefault(media.mediaType))
+            .contentLength(fileLength)
             .body(stream)
         }
       } catch (ex: FileNotFoundException) {


### PR DESCRIPTION
## What this PR does

Adds HTTP/1.1 Range request support ([RFC 7233](https://datatracker.ietf.org/doc/html/rfc7233)) to the shared book file download endpoint, covering:

- `GET api/v1/books/{bookId}/file`
- `GET opds/v1.2/books/{bookId}/file/*`
- `GET opds/v2/books/{bookId}/file`

## Why

OPDS clients (and other readers) that use the book file endpoint to open comic/book archives currently have to download the **entire file** before the reader can open it. For large CBZ files (e.g. 200–500 MB) this means waiting minutes before anything is visible.

ZIP-based formats (CBZ) store their index (the End of Central Directory record) at the **tail** of the file. A client that can issue a range request for the last ~128 KB gets everything it needs to parse the archive and start reading in 1–3 seconds, with individual pages streamed on demand thereafter. This is a well-established pattern used by browsers for PDF range loading and by tools like `yauzl`.

Without Range support, Komga responds with a chunked `200 OK` and no `Content-Length`, forcing any smart client to fall back to buffering the whole transfer before it can proceed.

## Changes

**`CommonBookController.kt`** (the single controller shared by REST and OPDS v1/v2):

| Scenario | Before | After |
|---|---|---|
| No `Range` header | `200 OK`, full file | `200 OK`, full file + `Accept-Ranges: bytes` |
| Valid single range (e.g. `bytes=0-131071`) | — | `206 Partial Content` with `Content-Range` header, data served via `RandomAccessFile.seek()` |
| Unsatisfiable range | — | `416 Range Not Satisfiable` with `Content-Range: bytes */$fileLength` |
| Multi-range request | — | Falls back to `200 OK` full response (multipart/byteranges is out of scope) |

- All responses now include **`Accept-Ranges: bytes`** so clients can discover the capability with a HEAD request.
- `RandomAccessFile.seek()` is used instead of stream-skipping for reliable and efficient random access.
- The `KoboController` call to `getBookFileInternal` is unaffected — the new `rangeHeader` parameter defaults to `null`.

## Testing

Existing `BookControllerTest` suite passes unchanged. The feature can be manually verified with:

```bash
# Should return HTTP/1.1 206 Partial Content + Content-Range header
curl -v -u admin:admin   -H "Range: bytes=0-131071"   http://localhost:8080/api/v1/books/<bookId>/file

# Should return HTTP/1.1 200 OK + Accept-Ranges: bytes (no Range header)
curl -v -u admin:admin   http://localhost:8080/api/v1/books/<bookId>/file

# Should return HTTP/1.1 416 Range Not Satisfiable
curl -v -u admin:admin   -H "Range: bytes=99999999999-"   http://localhost:8080/api/v1/books/<bookId>/file
```