### PR TITLE
fix(api): match `UserDto` with expected schema

### DIFF
--- a/komga/src/main/kotlin/org/gotson/komga/interfaces/api/rest/UserController.kt
+++ b/komga/src/main/kotlin/org/gotson/komga/interfaces/api/rest/UserController.kt
@@ -112,10 +112,12 @@ class UserController(
               restrictions =
                 ContentRestrictions(
                   ageRestriction =
-                    if (ageRestriction == null || ageRestriction.restriction == AllowExcludeDto.NONE)
-                      null
-                    else
-                      AgeRestriction(ageRestriction.age, ageRestriction.restriction.toDomain()),
+                    ageRestriction.let {
+                      if (it == null || it.restriction == AllowExcludeDto.NONE)
+                        null
+                      else
+                        AgeRestriction(it.age, it.restriction.toDomain())
+                    },
                   labelsAllow = labelsAllow ?: emptySet(),
                   labelsExclude = labelsExclude ?: emptySet(),
                 ),

--- a/komga/src/main/kotlin/org/gotson/komga/interfaces/api/rest/dto/UserDto.kt
+++ b/komga/src/main/kotlin/org/gotson/komga/interfaces/api/rest/dto/UserDto.kt
@@ -1,10 +1,12 @@
 package org.gotson.komga.interfaces.api.rest.dto
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import org.gotson.komga.domain.model.AgeRestriction
 import org.gotson.komga.domain.model.AllowExclude
 import org.gotson.komga.domain.model.KomgaUser
 import org.gotson.komga.infrastructure.security.KomgaPrincipal
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 data class UserDto(
   val id: String,
   val email: String,

--- a/komga/src/test/kotlin/org/gotson/komga/interfaces/api/rest/UserControllerTest.kt
+++ b/komga/src/test/kotlin/org/gotson/komga/interfaces/api/rest/UserControllerTest.kt
@@ -113,7 +113,7 @@ class UserControllerTest(
           jsonPath("$.sharedLibrariesId") { doesNotExist() }
           jsonPath("$.labelsAllow") { isEmpty() }
           jsonPath("$.labelsExclude") { isEmpty() }
-          jsonPath("$.ageRestriction") { isEmpty() }
+          jsonPath("$.ageRestriction") { doesNotExist() }
         }
     }
   }


### PR DESCRIPTION
the expected schema for `UserDto` is that `ageRestriction` is either the age restriction object or is omitted.  this change ensures that the DTO will drop the age restriction value instead of serializing it as `null`

fixes #2296