### PR TITLE
fix(api): return null for UserDto.ageRestriction instead of omitting

### DIFF
--- a/komga/src/main/kotlin/org/gotson/komga/interfaces/api/rest/dto/UserDto.kt
+++ b/komga/src/main/kotlin/org/gotson/komga/interfaces/api/rest/dto/UserDto.kt
@@ -1,12 +1,10 @@
 package org.gotson.komga.interfaces.api.rest.dto
 
-import com.fasterxml.jackson.annotation.JsonInclude
 import org.gotson.komga.domain.model.AgeRestriction
 import org.gotson.komga.domain.model.AllowExclude
 import org.gotson.komga.domain.model.KomgaUser
 import org.gotson.komga.infrastructure.security.KomgaPrincipal
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
 data class UserDto(
   val id: String,
   val email: String,

--- a/komga/src/test/kotlin/org/gotson/komga/interfaces/api/rest/UserControllerTest.kt
+++ b/komga/src/test/kotlin/org/gotson/komga/interfaces/api/rest/UserControllerTest.kt
@@ -113,7 +113,7 @@ class UserControllerTest(
           jsonPath("$.sharedLibrariesId") { doesNotExist() }
           jsonPath("$.labelsAllow") { isEmpty() }
           jsonPath("$.labelsExclude") { isEmpty() }
-          jsonPath("$.ageRestriction") { doesNotExist() }
+          jsonPath("$.ageRestriction") { isEmpty() }
         }
     }
   }


### PR DESCRIPTION
# Revert UserDto.ageRestriction to return null instead of omitting field

## Problem

Commit e3a8cc6 added `@JsonInclude(JsonInclude.Include.NON_NULL)` to `UserDto`, causing the `ageRestriction` field to be omitted entirely from the JSON response when a user has no age restriction set (e.g. the default admin account).

External API clients that deserialize `KomgaUser` with `ageRestriction` as a required field — such as komga-client v0.10.2 used by Komelia — throw a deserialization error at startup:

> field 'ageRestriction' is required for type with serial name 'snd.komga.client.user.KomgaUser' but it was missing at path

## Changes

- Removed `@JsonInclude(JsonInclude.Include.NON_NULL)` from `UserDto` so `ageRestriction` is returned as `null` in the response when not set, rather than being absent
- Reverted the test assertion from `doesNotExist()` back to `isEmpty()` to match the restored behaviour

## Impact

- Restores compatibility with external clients (Komelia, and any other app using komga-client) that rely on `ageRestriction` always being present in the response
- No functional change for users — a `null` `ageRestriction` is still treated as no restriction by the server
