### PR TITLE
build(komga-deps): Bump springboot to 3.5.14 and junrar to 7.5.10

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 sqliteJdbc = "3.50.2.0"
 nightmonkeys = "1.0.0"
 twelvemonkeys = "3.12.0"
-springboot = "3.5.4"
+springboot = "3.5.14"
 lucene = "9.9.1" # v10 requires JDK 21
 jooq = "3.19.24" # should be aligned with the version provided by Spring Boot
 

--- a/komga/build.gradle.kts
+++ b/komga/build.gradle.kts
@@ -78,7 +78,7 @@ dependencies {
 
   implementation("org.apache.tika:tika-core:2.9.1")
   implementation("org.apache.commons:commons-compress:1.27.1")
-  implementation("com.github.junrar:junrar:7.5.5")
+  implementation("com.github.junrar:junrar:7.5.10")
   implementation("com.github.gotson.nightcompress:nightcompress:1.1.1")
   implementation("org.apache.pdfbox:pdfbox:3.0.5")
   implementation("net.grey-panther:natural-comparator:1.1")


### PR DESCRIPTION
Trivy scan was reporting a bunch of CVEs, the majority were removed via the springboot bump so I guess they were just secondary dependencies. It's just a minor release bump so it should be okey. Did a quick test and could read pdf/epub/cbz.

Patched:
CVE-2025-11226
CVE-2026-1225
GHSA-72hv-8253-57qq
CVE-2026-28208
GHSA-hf5p-q87m-crj7
CVE-2025-53864
CVE-2025-58057
CVE-2026-33870
CVE-2025-67735
CVE-2025-58056
CVE-2025-55163
CVE-2026-33871
CVE-2026-29145
CVE-2025-48989
CVE-2025-55752
CVE-2026-24734
CVE-2026-34487
CVE-2025-66614
CVE-2026-25854
CVE-2026-34500
CVE-2025-55754
CVE-2025-61795
CVE-2026-24733
CVE-2025-41248
CVE-2026-22732
CVE-2025-41249
CVE-2026-22737
CVE-2026-22735
CVE-2025-41242
CVE-2026-22737
CVE-2026-22735
CVE-2026-40477
CVE-2026-40478
CVE-2026-40477
CVE-2026-40478