### PR TITLE
fix(webui): key reader to bookId to prevent stale images being shown

### DIFF
--- a/komga-webui/src/views/DivinaReader.vue
+++ b/komga-webui/src/views/DivinaReader.vue
@@ -121,7 +121,7 @@
       </v-slide-y-reverse-transition>
     </div>
 
-    <div class="full-height">
+    <div class="full-height" :key="bookId">
       <continuous-reader
         v-if="continuousReader"
         :pages="pages"


### PR DESCRIPTION
Adds the `bookId` as a key to the reader div to prevent images from the last book from being shown as described in https://github.com/gotson/komga/issues/2304.