### PR TITLE
feat(webui): client-side whole-archive preload for CBZ

### DIFF
--- a/komga-webui/package-lock.json
+++ b/komga-webui/package-lock.json
@@ -16,6 +16,7 @@
         "date-fns": "^2.30.0",
         "filesize": "^10.0.12",
         "js-file-downloader": "^1.1.25",
+        "jszip": "^3.10.1",
         "language-tags": "^1.0.9",
         "lodash": "^4.18.1",
         "marked": "^15.0.4",
@@ -10244,6 +10245,12 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/immutable": {
       "version": "4.3.8",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.8.tgz",
@@ -13377,6 +13384,54 @@
         "node": ">=0.6.0"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.3",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz",
@@ -13471,6 +13526,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lilconfig": {
@@ -14880,6 +14944,12 @@
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/param-case": {
       "version": "3.0.4",
@@ -17118,6 +17188,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -27857,6 +27933,11 @@
         "queue": "6.0.2"
       }
     },
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+    },
     "immutable": {
       "version": "4.3.8",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.8.tgz",
@@ -30154,6 +30235,51 @@
         "verror": "1.10.0"
       }
     },
+    "jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "requires": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+        },
+        "readable-stream": {
+          "version": "2.3.8",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+          "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "keyv": {
       "version": "4.5.3",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz",
@@ -30230,6 +30356,14 @@
       "requires": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
+      }
+    },
+    "lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "requires": {
+        "immediate": "~3.0.5"
       }
     },
     "lilconfig": {
@@ -31286,6 +31420,11 @@
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true
+    },
+    "pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "param-case": {
       "version": "3.0.4",
@@ -32891,6 +33030,11 @@
         "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0"
       }
+    },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "setprototypeof": {
       "version": "1.2.0",

--- a/komga-webui/package.json
+++ b/komga-webui/package.json
@@ -17,6 +17,7 @@
     "date-fns": "^2.30.0",
     "filesize": "^10.0.12",
     "js-file-downloader": "^1.1.25",
+    "jszip": "^3.10.1",
     "language-tags": "^1.0.9",
     "lodash": "^4.18.1",
     "marked": "^15.0.4",

--- a/komga-webui/src/functions/whole-archive-preload.ts
+++ b/komga-webui/src/functions/whole-archive-preload.ts
@@ -11,6 +11,22 @@ export interface WholeArchivePreloaderOpts {
   $debug?: (...args: any[]) => void
 }
 
+/**
+ * Returns 0-based page indices in decode priority order: current page first,
+ * then forward to the end, then wrapping to the start of the book.
+ *
+ * Defensive against non-finite currentPageOneBased (treated as page 1).
+ */
+export function computePreloadOrder(currentPageOneBased: number, pageCount: number): number[] {
+  if (pageCount <= 0) return []
+  const safeCurrent = Number.isFinite(currentPageOneBased) ? currentPageOneBased : 1
+  const cur = Math.min(Math.max(0, safeCurrent - 1), pageCount - 1)
+  const order: number[] = []
+  for (let i = cur; i < pageCount; i++) order.push(i)
+  for (let i = 0; i < cur; i++) order.push(i)
+  return order
+}
+
 export class WholeArchivePreloader {
   private controller = new AbortController()
   private blobUrls: string[] = []
@@ -34,10 +50,7 @@ export class WholeArchivePreloader {
       const zip = await JSZip.loadAsync(buf)
       if (this.aborted()) return
 
-      const cur = Math.max(0, getCurrentPage() - 1)
-      const order: number[] = []
-      for (let i = cur; i < pages.length; i++) order.push(i)
-      for (let i = 0; i < cur; i++) order.push(i)
+      const order = computePreloadOrder(getCurrentPage(), pages.length)
 
       for (const idx of order) {
         if (this.aborted()) return

--- a/komga-webui/src/functions/whole-archive-preload.ts
+++ b/komga-webui/src/functions/whole-archive-preload.ts
@@ -1,0 +1,79 @@
+import JSZip from 'jszip'
+import {bookFileUrl} from '@/functions/urls'
+import {PageDtoWithUrl} from '@/types/komga-books'
+
+export interface WholeArchivePreloaderOpts {
+  bookId: string
+  supportedMediaTypes: string[]
+  pages: PageDtoWithUrl[]
+  getCurrentPage: () => number
+  applyUrl: (idx: number, url: string) => void
+  $debug?: (...args: any[]) => void
+}
+
+export class WholeArchivePreloader {
+  private controller = new AbortController()
+  private blobUrls: string[] = []
+  private disposed = false
+
+  constructor(private opts: WholeArchivePreloaderOpts) {}
+
+  async run(): Promise<void> {
+    const {bookId, pages, supportedMediaTypes, getCurrentPage, applyUrl, $debug} = this.opts
+    try {
+      const res = await fetch(bookFileUrl(bookId), {
+        credentials: 'include',
+        signal: this.controller.signal,
+      })
+      if (!res.ok) {
+        $debug?.('[whole-archive-preload] /file returned', res.status)
+        return
+      }
+      const buf = await res.arrayBuffer()
+      if (this.aborted()) return
+      const zip = await JSZip.loadAsync(buf)
+      if (this.aborted()) return
+
+      const cur = Math.max(0, getCurrentPage() - 1)
+      const order: number[] = []
+      for (let i = cur; i < pages.length; i++) order.push(i)
+      for (let i = 0; i < cur; i++) order.push(i)
+
+      for (const idx of order) {
+        if (this.aborted()) return
+        // 用户已经读到最后两页，剩余受益太小，主动收手
+        if (getCurrentPage() >= pages.length - 1) return
+        const page = pages[idx]
+        if (!supportedMediaTypes.includes(page.mediaType)) continue
+        const entry = zip.file(page.fileName)
+        if (!entry) {
+          $debug?.('[whole-archive-preload] entry missing in archive', page.fileName)
+          continue
+        }
+        const u8 = await entry.async('uint8array')
+        if (this.aborted()) return
+        const blob = new Blob([u8], {type: page.mediaType})
+        const url = URL.createObjectURL(blob)
+        this.blobUrls.push(url)
+        applyUrl(idx, url)
+      }
+    } catch (e: any) {
+      if (e?.name !== 'AbortError') this.opts.$debug?.('[whole-archive-preload] failed', e)
+    }
+  }
+
+  private aborted(): boolean {
+    return this.disposed || this.controller.signal.aborted
+  }
+
+  cancel(): void {
+    this.controller.abort()
+  }
+
+  dispose(): void {
+    this.disposed = true
+    this.controller.abort()
+    this.blobUrls.forEach(URL.revokeObjectURL)
+    this.blobUrls.length = 0
+  }
+}

--- a/komga-webui/src/locales/en.json
+++ b/komga-webui/src/locales/en.json
@@ -126,6 +126,7 @@
     "set_current_page_as_readlist_poster": "Set page as poster for read list",
     "set_current_page_as_series_poster": "Set page as poster for series",
     "settings": {
+      "advanced": "Advanced",
       "always_fullscreen": "Always Full Screen",
       "animate_page_transitions": "Animate page transitions",
       "background_color": "Background color",
@@ -140,6 +141,9 @@
       "page_layout": "Page layout",
       "page_margin": "Page margin",
       "paged": "Paginated Reader Options",
+      "preload_disabled": "Disabled",
+      "preload_max_size": "Preload whole archive (max size)",
+      "preload_requires_file_download": "Preload requires File Download permission",
       "reading_mode": "Reading mode",
       "scale_type": "Scale type",
       "side_padding": "Side padding",

--- a/komga-webui/src/locales/en.json
+++ b/komga-webui/src/locales/en.json
@@ -27,7 +27,11 @@
     },
     "change_password": "change password",
     "details": "Details",
-    "my_account": "My Account"
+    "my_account": "My Account",
+    "preload_disabled": "Disabled",
+    "preload_hint": "Download the whole archive once when opening a book and serve pages from local memory. Reduces request count on unstable networks.",
+    "preload_max_size": "Preload whole archive (max size)",
+    "preload_requires_file_download": "Preload requires File Download permission"
   },
   "announcements": {
     "mark_all_read": "Mark all as read",
@@ -126,7 +130,6 @@
     "set_current_page_as_readlist_poster": "Set page as poster for read list",
     "set_current_page_as_series_poster": "Set page as poster for series",
     "settings": {
-      "advanced": "Advanced",
       "always_fullscreen": "Always Full Screen",
       "animate_page_transitions": "Animate page transitions",
       "background_color": "Background color",
@@ -141,9 +144,6 @@
       "page_layout": "Page layout",
       "page_margin": "Page margin",
       "paged": "Paginated Reader Options",
-      "preload_disabled": "Disabled",
-      "preload_max_size": "Preload whole archive (max size)",
-      "preload_requires_file_download": "Preload requires File Download permission",
       "reading_mode": "Reading mode",
       "scale_type": "Scale type",
       "side_padding": "Side padding",

--- a/komga-webui/src/plugins/persisted-state.ts
+++ b/komga-webui/src/plugins/persisted-state.ts
@@ -20,6 +20,7 @@ export const persistedModule: Module<any, any> = {
       alwaysFullscreen: false,
       animations: true,
       background: '',
+      wholeArchivePreloadMaxMb: 0,
     },
     epubreader: {},
     browsingPageSize: undefined as unknown as number,
@@ -129,6 +130,9 @@ export const persistedModule: Module<any, any> = {
     },
     setWebreaderBackground(state, val) {
       state.webreader.background = val
+    },
+    setWebreaderPreloadMaxMb(state, val) {
+      state.webreader.wholeArchivePreloadMaxMb = val
     },
     setEpubreaderSettings(state, val) {
       state.epubreader = val

--- a/komga-webui/src/views/AccountView.vue
+++ b/komga-webui/src/views/AccountView.vue
@@ -30,6 +30,25 @@
       </v-col>
     </v-row>
 
+    <v-row align="center">
+      <v-col cols="12" md="8" lg="6" xl="4">
+        <span>{{ $t('account_settings.preload_max_size') }}</span>
+        <v-select
+          :items="preloadSizeOptions"
+          v-model="preloadMaxMb"
+          dense
+          filled
+          hide-details
+        />
+        <div class="text-caption text--secondary mt-2">
+          {{ $t('account_settings.preload_hint') }}
+        </div>
+        <div v-if="!$store.getters.meFileDownload" class="text-caption text--secondary mt-1">
+          {{ $t('account_settings.preload_requires_file_download') }}
+        </div>
+      </v-col>
+    </v-row>
+
     <password-change-dialog v-model="modalPasswordChange"
                             :user="me"
     />
@@ -54,6 +73,25 @@ export default Vue.extend({
   computed: {
     me(): UserDto {
       return this.$store.state.komgaUsers.me
+    },
+    preloadMaxMb: {
+      get(): number {
+        return this.$store.state.persistedState.webreader.wholeArchivePreloadMaxMb ?? 0
+      },
+      set(val: number): void {
+        this.$store.commit('setWebreaderPreloadMaxMb', val)
+      },
+    },
+    preloadSizeOptions(): { text: string, value: number }[] {
+      return [
+        {text: this.$t('account_settings.preload_disabled').toString(), value: 0},
+        {text: '10 MB', value: 10},
+        {text: '20 MB', value: 20},
+        {text: '50 MB', value: 50},
+        {text: '100 MB', value: 100},
+        {text: '200 MB', value: 200},
+        {text: '500 MB', value: 500},
+      ]
     },
   },
 })

--- a/komga-webui/src/views/DivinaReader.vue
+++ b/komga-webui/src/views/DivinaReader.vue
@@ -711,7 +711,6 @@ export default Vue.extend({
       const pageDtos = (await this.$komgaBooks.getBookPages(bookId))
       pageDtos.forEach((p: any) => p['url'] = this.getPageUrl(p))
       this.pages = pageDtos as PageDtoWithUrl[]
-      this.maybeStartPreload()
 
       this.$debug('[setup]', `pages count:${this.pagesCount}`, 'read progress:', this.book.readProgress)
       if (page && page >= 1 && page <= this.pagesCount) {
@@ -721,6 +720,7 @@ export default Vue.extend({
       } else {
         this.goToFirst()
       }
+      this.maybeStartPreload()
 
       // set non-persistent reading direction if exists in metadata
       if (this.series.metadata.readingDirection in ReadingDirection && this.readingDirection !== this.series.metadata.readingDirection) {

--- a/komga-webui/src/views/DivinaReader.vue
+++ b/komga-webui/src/views/DivinaReader.vue
@@ -250,6 +250,17 @@
               </v-list-item>
             </template>
 
+            <v-subheader class="font-weight-black text-h6">{{ $t('bookreader.settings.advanced') }}</v-subheader>
+            <v-list-item>
+              <settings-select
+                :items="preloadSizeOptions"
+                v-model="preloadMaxMb"
+                :label="$t('bookreader.settings.preload_max_size')"
+              />
+            </v-list-item>
+            <v-list-item v-if="!$store.getters.meFileDownload" class="text-caption text--secondary">
+              {{ $t('bookreader.settings.preload_requires_file_download') }}
+            </v-list-item>
 
           </v-list>
         </v-card-text>
@@ -324,6 +335,7 @@ import ShortcutHelpDialog from '@/components/dialogs/ShortcutHelpDialog.vue'
 import {getBookTitleCompact} from '@/functions/book-title'
 import {checkImageSupport, ImageFeature} from '@/functions/check-image'
 import {bookPageUrl} from '@/functions/urls'
+import {WholeArchivePreloader} from '@/functions/whole-archive-preload'
 import {getFileFromUrl} from '@/functions/file'
 import {resizeImageFile} from '@/functions/resize-image'
 import {ReadingDirection} from '@/types/enum-books'
@@ -380,6 +392,7 @@ export default Vue.extend({
       },
       pages: [] as PageDtoWithUrl[],
       page: undefined as unknown as number,
+      preloader: null as WholeArchivePreloader | null,
       supportedMediaTypes: ['image/jpeg', 'image/png', 'image/gif'],
       convertTo: 'jpeg',
       showExplorer: false,
@@ -471,6 +484,9 @@ export default Vue.extend({
   },
   destroyed() {
     document.documentElement.classList.remove('html-reader')
+
+    this.preloader?.dispose()
+    this.preloader = null
 
     this.$vuetify.rtl = (this.$t('common.locale_rtl') === 'true')
     window.removeEventListener('keydown', this.keyPressed)
@@ -621,6 +637,25 @@ export default Vue.extend({
         }
       },
     },
+    preloadMaxMb: {
+      get: function (): number {
+        return this.$store.state.persistedState.webreader.wholeArchivePreloadMaxMb ?? 0
+      },
+      set: function (val: number): void {
+        this.$store.commit('setWebreaderPreloadMaxMb', val)
+      },
+    },
+    preloadSizeOptions(): { text: string, value: number }[] {
+      return [
+        {text: this.$t('bookreader.settings.preload_disabled').toString(), value: 0},
+        {text: '10 MB', value: 10},
+        {text: '20 MB', value: 20},
+        {text: '50 MB', value: 50},
+        {text: '100 MB', value: 100},
+        {text: '200 MB', value: 200},
+        {text: '500 MB', value: 500},
+      ]
+    },
     readingDirection: {
       get: function (): ReadingDirection {
         return this.settings.readingDirection
@@ -707,6 +742,7 @@ export default Vue.extend({
       const pageDtos = (await this.$komgaBooks.getBookPages(bookId))
       pageDtos.forEach((p: any) => p['url'] = this.getPageUrl(p))
       this.pages = pageDtos as PageDtoWithUrl[]
+      this.maybeStartPreload()
 
       this.$debug('[setup]', `pages count:${this.pagesCount}`, 'read progress:', this.book.readProgress)
       if (page && page >= 1 && page <= this.pagesCount) {
@@ -751,6 +787,29 @@ export default Vue.extend({
       } else {
         return bookPageUrl(this.bookId, page.number)
       }
+    },
+    maybeStartPreload() {
+      this.preloader?.dispose()
+      this.preloader = null
+
+      const maxMb = this.preloadMaxMb
+      if (maxMb <= 0) return
+      if (!this.$store.getters.meFileDownload) return
+      if (this.book.media.mediaType !== 'application/zip') return
+      if ((this.book.media.mediaProfile || '').toUpperCase() !== 'DIVINA') return
+      if (this.book.sizeBytes / 1024 / 1024 > maxMb) return
+      if (this.pagesCount - this.page < 5) return
+
+      this.preloader = new WholeArchivePreloader({
+        bookId: this.bookId,
+        supportedMediaTypes: this.supportedMediaTypes,
+        pages: this.pages,
+        getCurrentPage: () => this.page,
+        applyUrl: (idx, url) => this.$set(this.pages[idx], 'url', url),
+        $debug: this.$debug,
+      })
+      // 让首屏 /pages 请求先打出去再发 /file
+      this.$nextTick(() => { this.preloader?.run() })
     },
     jumpToPrevious() {
       if (this.jumpToPreviousBook) {

--- a/komga-webui/src/views/DivinaReader.vue
+++ b/komga-webui/src/views/DivinaReader.vue
@@ -250,18 +250,6 @@
               </v-list-item>
             </template>
 
-            <v-subheader class="font-weight-black text-h6">{{ $t('bookreader.settings.advanced') }}</v-subheader>
-            <v-list-item>
-              <settings-select
-                :items="preloadSizeOptions"
-                v-model="preloadMaxMb"
-                :label="$t('bookreader.settings.preload_max_size')"
-              />
-            </v-list-item>
-            <v-list-item v-if="!$store.getters.meFileDownload" class="text-caption text--secondary">
-              {{ $t('bookreader.settings.preload_requires_file_download') }}
-            </v-list-item>
-
           </v-list>
         </v-card-text>
       </v-card>
@@ -637,25 +625,6 @@ export default Vue.extend({
         }
       },
     },
-    preloadMaxMb: {
-      get: function (): number {
-        return this.$store.state.persistedState.webreader.wholeArchivePreloadMaxMb ?? 0
-      },
-      set: function (val: number): void {
-        this.$store.commit('setWebreaderPreloadMaxMb', val)
-      },
-    },
-    preloadSizeOptions(): { text: string, value: number }[] {
-      return [
-        {text: this.$t('bookreader.settings.preload_disabled').toString(), value: 0},
-        {text: '10 MB', value: 10},
-        {text: '20 MB', value: 20},
-        {text: '50 MB', value: 50},
-        {text: '100 MB', value: 100},
-        {text: '200 MB', value: 200},
-        {text: '500 MB', value: 500},
-      ]
-    },
     readingDirection: {
       get: function (): ReadingDirection {
         return this.settings.readingDirection
@@ -792,7 +761,7 @@ export default Vue.extend({
       this.preloader?.dispose()
       this.preloader = null
 
-      const maxMb = this.preloadMaxMb
+      const maxMb = this.$store.state.persistedState.webreader.wholeArchivePreloadMaxMb ?? 0
       if (maxMb <= 0) return
       if (!this.$store.getters.meFileDownload) return
       if (this.book.media.mediaType !== 'application/zip') return

--- a/komga-webui/tests/unit/functions/whole-archive-preload.spec.ts
+++ b/komga-webui/tests/unit/functions/whole-archive-preload.spec.ts
@@ -1,0 +1,29 @@
+import {computePreloadOrder} from '@/functions/whole-archive-preload'
+
+describe('computePreloadOrder', () => {
+  test('empty book returns empty order', () => {
+    expect(computePreloadOrder(1, 0)).toEqual([])
+  })
+
+  test('starting at first page goes forward through the whole book', () => {
+    expect(computePreloadOrder(1, 5)).toEqual([0, 1, 2, 3, 4])
+  })
+
+  test('starting mid-book prioritises forward then wraps to start', () => {
+    expect(computePreloadOrder(3, 5)).toEqual([2, 3, 4, 0, 1])
+  })
+
+  test('starting at last page wraps cleanly', () => {
+    expect(computePreloadOrder(5, 5)).toEqual([4, 0, 1, 2, 3])
+  })
+
+  test('non-finite current page falls back to page 1', () => {
+    expect(computePreloadOrder(NaN, 3)).toEqual([0, 1, 2])
+    expect(computePreloadOrder(undefined as unknown as number, 3)).toEqual([0, 1, 2])
+  })
+
+  test('out-of-range current page is clamped', () => {
+    expect(computePreloadOrder(0, 3)).toEqual([0, 1, 2])
+    expect(computePreloadOrder(99, 3)).toEqual([2, 0, 1])
+  })
+})


### PR DESCRIPTION
## What this PR does

Adds an opt-in setting (Account → *Preload whole archive*) that, when reading a CBZ book, downloads the archive once via `/api/v1/books/{id}/file`, unzips it client-side with JSZip, and replaces each page URL with a `blob:` URL pointed at the in-memory image. Subsequent page navigation is served entirely from the local Blob — no further `/pages/{n}` requests against the server.

No server changes.

## Why

On unstable or high-latency networks, the per-page model of `DivinaReader` produces dozens of small `/pages/{n}` requests per book. Each request:
- pays a round-trip
- on the server side, re-opens the archive and seeks to the entry (especially expensive when the library lives on a remote / rclone mount)
- multiplies the chance that a single flaky request stalls the reader

For users in this situation, paying one larger `/file` GET up-front and serving the rest from a local Blob materially improves the reading experience, at the cost of memory and an initial download.

## How it works

`komga-webui/src/functions/whole-archive-preload.ts` is a small class invoked from `DivinaReader.vue` after the initial `pages` list is fetched:

1. `fetch('/api/v1/books/{id}/file')` with `AbortController` so navigating away cancels the transfer.
2. `JSZip.loadAsync(buf)` to parse the central directory.
3. Iterate pages **starting from the current page forward**, then wrapping to the beginning — this prioritises what the reader is about to render. Pages whose `mediaType` the browser can't decode natively (AVIF / JXL / WebP if unsupported) are skipped, so they continue to use the server's content-negotiation path via `/pages`.
4. For each entry, decode to `Uint8Array`, wrap in a `Blob`, `URL.createObjectURL`, and `Vue.set` the page's `url` to the blob URL. The reader's `<img>` reactively swaps over.
5. On book switch / component destroy: `AbortController.abort()` + `URL.revokeObjectURL()` for every created blob.

The reader's natural prefetch window (a handful of pages around the current one) is **not** delayed — those fall through to the normal `/pages` path while the archive is still downloading, giving instant first paint. The win is on the long tail.

## Gating

Preload only kicks in when **all** of the following hold:
- the user has the `FILE_DOWNLOAD` role (required to hit `/file`)
- `book.media.mediaType === 'application/zip'` and `mediaProfile === 'DIVINA'` (CBZ only — RAR / EPUB / PDF are not in scope here)
- `book.sizeBytes` ≤ the user-selected size threshold
- there are at least 5 pages left to read (avoids spending bandwidth on a book the user is about to finish)

## Configuration

A new control on the Account page exposes the size threshold:

> **Preload whole archive (max size)** — Disabled / 10 / 20 / 50 / 100 / 200 / 500 MB
>
> Download the whole archive once when opening a book and serve pages from local memory. Reduces request count on unstable networks.

Default is **Disabled**, so existing users see no behaviour change.

The preference lives in `persistedState.webreader.wholeArchivePreloadMaxMb` (localStorage). Per-device on purpose — what works on a desktop with 16 GB RAM is different from a phone on cellular. No DB migration, no `/users/me` extension.

If the user lacks `FILE_DOWNLOAD`, a hint is shown under the dropdown.

## Files

- `komga-webui/src/functions/whole-archive-preload.ts` — new (79 lines)
- `komga-webui/src/views/DivinaReader.vue` — wire up / dispose preloader
- `komga-webui/src/views/AccountView.vue` — the new control
- `komga-webui/src/plugins/persisted-state.ts` — new persisted field + mutation
- `komga-webui/src/locales/en.json` — 4 new keys under `account_settings.*`
- `komga-webui/package.json` + `package-lock.json` — adds `jszip`

## Testing

- `npm run lint` clean
- `npm run build` green
- Manually verified on a CBZ library:
  - With preload disabled (default): unchanged behaviour, per-page `/pages` requests as before
  - With preload enabled and book size under threshold: initial reader window served via `/pages` (≈ 6 requests), one `/file` GET, then all subsequent navigation served from `blob:` URLs — `Network` tab shows no further `/pages` requests
  - Book switch / closing the reader mid-download: `/file` request cancelled via `AbortController`, blob URLs revoked
  - Threshold respected: a 600 MB CBZ does not preload at the 500 MB setting
  - `FILE_DOWNLOAD` permission removed: preload disabled, hint shown under the setting


## Screenshots

<img width="921" height="618" alt="image" src="https://github.com/user-attachments/assets/214e5c06-a1cb-41e5-bf53-ca8ccae7f7d6" />

<img width="543" height="496" alt="image" src="https://github.com/user-attachments/assets/ff1cba6a-d596-4fa0-9f5f-ac4d60c1c5dc" />

Once the whole cbz file is downloaded, the following image requests will be local blob only.

## Notes / Out of scope

- **RAR / 7z**: would require shipping a WASM unrar/un7z library — significant size and a separate decision. Not included.
- **EPUB-as-Divina**: technically straightforward (EPUB is zip) but needs verification of `page.fileName` path handling inside the EPUB's `OEBPS/` layout. Happy to do as a follow-up if this direction is welcome.
- **PDF**: doesn't fit this pattern — would need PDF.js client-side rendering, a separate effort.
- **Server-side persistence of the setting**: kept in localStorage to avoid schema / DTO churn. If you'd prefer it cross-device, that seems like a separate PR migrating `webreader.*` preferences as a whole.