### PR TITLE
fix(search): normalize titles to Unicode NFC for indexing and search

### DIFF
--- a/komga/src/main/kotlin/org/gotson/komga/infrastructure/search/MultiLingualAnalyzer.kt
+++ b/komga/src/main/kotlin/org/gotson/komga/infrastructure/search/MultiLingualAnalyzer.kt
@@ -8,6 +8,9 @@ import org.apache.lucene.analysis.cjk.CJKBigramFilter
 import org.apache.lucene.analysis.cjk.CJKWidthFilter
 import org.apache.lucene.analysis.miscellaneous.ASCIIFoldingFilter
 import org.apache.lucene.analysis.standard.StandardTokenizer
+import java.io.Reader
+import java.io.StringReader
+import java.text.Normalizer
 
 open class MultiLingualAnalyzer : Analyzer() {
   override fun createComponents(fieldName: String): TokenStreamComponents {
@@ -29,4 +32,20 @@ open class MultiLingualAnalyzer : Analyzer() {
     filter = ASCIIFoldingFilter(filter)
     return filter
   }
+
+  // Normalize the input to Unicode NFC (precomposed form) before tokenizing.
+  // This runs at both index time and query time, since createComponents/normalize read from
+  // the reader returned here. Some filesystems (e.g. SMB shares on macOS) expose filenames in
+  // decomposed form (NFD), so auto-generated titles would be indexed as NFD while search queries
+  // are sent as NFC. Without normalization the two never match (e.g. Korean Hangul). Applying NFC
+  // consistently on both sides makes NFD filenames searchable with NFC queries and vice versa.
+  override fun initReader(
+    fieldName: String?,
+    reader: Reader,
+  ): Reader = StringReader(Normalizer.normalize(reader.readText(), Normalizer.Form.NFC))
+
+  override fun initReaderForNormalization(
+    fieldName: String?,
+    reader: Reader,
+  ): Reader = StringReader(Normalizer.normalize(reader.readText(), Normalizer.Form.NFC))
 }

--- a/komga/src/main/kotlin/org/gotson/komga/infrastructure/search/SearchIndexLifecycle.kt
+++ b/komga/src/main/kotlin/org/gotson/komga/infrastructure/search/SearchIndexLifecycle.kt
@@ -21,7 +21,7 @@ import kotlin.math.ceil
 import kotlin.time.measureTime
 
 private val logger = KotlinLogging.logger {}
-private const val INDEX_VERSION = 8
+private const val INDEX_VERSION = 9
 
 @Component
 class SearchIndexLifecycle(

--- a/komga/src/main/kotlin/org/gotson/komga/interfaces/scheduler/SearchIndexController.kt
+++ b/komga/src/main/kotlin/org/gotson/komga/interfaces/scheduler/SearchIndexController.kt
@@ -3,7 +3,6 @@ package org.gotson.komga.interfaces.scheduler
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.gotson.komga.application.tasks.HIGHEST_PRIORITY
 import org.gotson.komga.application.tasks.TaskEmitter
-import org.gotson.komga.infrastructure.search.LuceneEntity
 import org.gotson.komga.infrastructure.search.LuceneHelper
 import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.context.annotation.Profile
@@ -29,10 +28,11 @@ class SearchIndexController(
       when {
         indexVersion < 6 -> {
           taskEmitter.upgradeIndex(HIGHEST_PRIORITY) // upgrade index to Lucene 9.x
-          taskEmitter.rebuildIndex(HIGHEST_PRIORITY, setOf(LuceneEntity.Series))
+          taskEmitter.rebuildIndex(HIGHEST_PRIORITY) // full rebuild to apply Unicode NFC normalization
         }
 
-        indexVersion < 8 -> taskEmitter.rebuildIndex(HIGHEST_PRIORITY, setOf(LuceneEntity.Series))
+        // NFC normalization (index version 9) affects every entity type, so a full rebuild is required
+        indexVersion < 9 -> taskEmitter.rebuildIndex(HIGHEST_PRIORITY)
       }
     }
   }

--- a/komga/src/test/kotlin/org/gotson/komga/infrastructure/search/MultilingualAnalyzerTest.kt
+++ b/komga/src/test/kotlin/org/gotson/komga/infrastructure/search/MultilingualAnalyzerTest.kt
@@ -2,6 +2,7 @@ package org.gotson.komga.infrastructure.search
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import java.text.Normalizer
 
 class MultilingualAnalyzerTest {
   private val analyzer = MultiLingualAnalyzer()
@@ -112,5 +113,22 @@ class MultilingualAnalyzerTest {
 
     // then
     assertThat(tokens).containsExactly("고교", "교생", "생을", "환불", "불해", "주세", "세요")
+  }
+
+  @Test
+  fun `korean decomposed NFD yields the same tokens as precomposed NFC`() {
+    // given - the same Korean title in precomposed (NFC) and decomposed (NFD) form,
+    // as produced by some filesystems (e.g. SMB shares on macOS)
+    val nfc = Normalizer.normalize("바스타드", Normalizer.Form.NFC)
+    val nfd = Normalizer.normalize("바스타드", Normalizer.Form.NFD)
+    assertThat(nfd).isNotEqualTo(nfc) // sanity check: the two Unicode forms really differ
+
+    // when
+    val tokensFromNfc = analyzer.getTokens(nfc)
+    val tokensFromNfd = analyzer.getTokens(nfd)
+
+    // then - both forms yield identical tokens, so an NFD-indexed title matches an NFC query and vice versa
+    assertThat(tokensFromNfd).isEqualTo(tokensFromNfc)
+    assertThat(tokensFromNfc).containsExactly("바스", "스타", "타드")
   }
 }

--- a/komga/src/test/kotlin/org/gotson/komga/infrastructure/search/MultilingualNGramAnalyzerTest.kt
+++ b/komga/src/test/kotlin/org/gotson/komga/infrastructure/search/MultilingualNGramAnalyzerTest.kt
@@ -2,6 +2,7 @@ package org.gotson.komga.infrastructure.search
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import java.text.Normalizer
 
 class MultilingualNGramAnalyzerTest {
   @Test
@@ -76,5 +77,23 @@ class MultilingualNGramAnalyzerTest {
 
     // then
     assertThat(tokens).containsExactly("고교", "교생", "생을", "환불", "불해", "주세", "세요")
+  }
+
+  @Test
+  fun `korean decomposed NFD is indexed with the same terms as precomposed NFC`() {
+    // given - the same Korean title in precomposed (NFC) and decomposed (NFD) form
+    val nfc = Normalizer.normalize("바스타드", Normalizer.Form.NFC)
+    val nfd = Normalizer.normalize("바스타드", Normalizer.Form.NFD)
+    assertThat(nfd).isNotEqualTo(nfc) // sanity check: the two Unicode forms really differ
+
+    val analyzer = MultiLingualNGramAnalyzer(3, 8, true)
+
+    // when
+    val tokensFromNfc = analyzer.getTokens(nfc)
+    val tokensFromNfd = analyzer.getTokens(nfd)
+
+    // then - the index analyzer stores identical terms regardless of the input Unicode form
+    assertThat(tokensFromNfd).isEqualTo(tokensFromNfc)
+    assertThat(tokensFromNfc).isNotEmpty
   }
 }


### PR DESCRIPTION
### Problem
Titles imported from filesystems that expose filenames in Unicode decomposed form (NFD) — notably SMB shares on macOS — are indexed as NFD, while search queries from the browser are sent in composed form (NFC). The Lucene analyzer chain never normalizes Unicode composition, so the indexed terms and query terms never match. Korean (Hangul) titles are the most visible casualty: they are unsearchable until the metadata is manually re-saved (which stores NFC).

### Fix
Normalize the analyzer input to NFC in `MultiLingualAnalyzer.initReader` / `initReaderForNormalization`. This analyzer backs both indexing (through the `MultiLingualNGramAnalyzer` subclass) and querying, so decomposed and composed forms now produce identical terms and match consistently. Normalization is idempotent for already-composed text, so existing NFC content is unaffected.

### Reindex
Existing indexes contain NFD terms, so the index version is bumped 8 → 9 to trigger an automatic full rebuild on startup for any pre-9 index. No manual action required.

### Tests
Added unit tests asserting NFD and NFC forms of a Korean title produce identical tokens for both the search and index analyzers. Validated empirically against Lucene 9.9.1: without the fix, NFD `바스타드` indexes as `[바, ᅡᄉ, 스, …]` vs NFC query `[바스, 스타, 타드]` (no match); with the fix both yield `[바스, 스타, 타드]`.

Fixes #2348