### PR TITLE
fix(api): preserve modified date in R2 progression

### DIFF
--- a/komga/src/main/kotlin/org/gotson/komga/domain/model/R2Progression.kt
+++ b/komga/src/main/kotlin/org/gotson/komga/domain/model/R2Progression.kt
@@ -1,6 +1,6 @@
 package org.gotson.komga.domain.model
 
-import org.gotson.komga.language.toZonedDateTime
+import org.gotson.komga.language.toUTCZoned
 import java.time.ZonedDateTime
 
 data class R2Progression(
@@ -11,7 +11,7 @@ data class R2Progression(
 
 fun ReadProgress.toR2Progression() =
   R2Progression(
-    modified = readDate.toZonedDateTime(),
+    modified = readDate.toUTCZoned(),
     device = R2Device(deviceId, deviceName),
     locator = locator ?: R2Locator("", ""),
   )


### PR DESCRIPTION
ReadProgressDao converts READ_DATE from UTC to the server local time when loading a progression. R2Progression then passed that local value to toZonedDateTime(), which treats it as UTC and shifts the returned modified instant by the server local UTC offset.

Use toUTCZoned() so GET /progression preserves the instant submitted by the client. This fixes incorrect modified timestamps in non-UTC server timezones without changing stored READ_DATE values.