### PR TITLE
ci: protect the release pipeline with pinned actions and scoped tokens

### DIFF
--- a/.github/workflows/browserlist-update.yml
+++ b/.github/workflows/browserlist-update.yml
@@ -23,7 +23,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - name: Update Browserslist database and create PR if applies
-        uses: c2corg/browserslist-update-action@v2
+        uses: c2corg/browserslist-update-action@a76abb476199caea5399f9e28ff3f16e491ec566 # v2.5.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: browserslist-update

--- a/.github/workflows/chromatic-pr.yml
+++ b/.github/workflows/chromatic-pr.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - 'master'
 
+permissions:
+  contents: read
+
 jobs:
   chromatic:
     name: Run Chromatic
@@ -36,7 +39,7 @@ jobs:
 
       - name: Run Chromatic
         id: chromatic
-        uses: chromaui/action@latest
+        uses: chromaui/action@14cfaef73576e69f95f47f60058063f46ca38719 # v18.1.0
         with:
           workingDir: next-ui
           exitOnceUploaded: true

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - 'master'
 
+permissions:
+  contents: read
+
 jobs:
   chromatic:
     name: Run Chromatic
@@ -30,7 +33,7 @@ jobs:
 
       - name: Run Chromatic
         id: chromatic
-        uses: chromaui/action@latest
+        uses: chromaui/action@14cfaef73576e69f95f47f60058063f46ca38719 # v18.1.0
         with:
           workingDir: next-ui
           exitOnceUploaded: true

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -6,12 +6,15 @@ on:
     paths:
       - '**/openapi.json'
 
+# The dispatch call authenticates with a PAT, the job token is not used.
+permissions: {}
+
 jobs:
   dispatch:
     runs-on: ubuntu-latest
     steps:
       - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v4
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           repository: gotson/komga-website

--- a/.github/workflows/dockerhub_description.yml
+++ b/.github/workflows/dockerhub_description.yml
@@ -7,6 +7,9 @@ on:
     paths:
     - 'DOCKERHUB.md'
 
+permissions:
+  contents: read
+
 jobs:
   update_docker_description:
     name: Update DockerHub description
@@ -15,7 +18,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: DockerHub Description
-      uses: peter-evans/dockerhub-description@v5.0.0
+      uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0
       env:
         DOCKERHUB_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKERHUB_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/github-releases-to-discord.yml
+++ b/.github/workflows/github-releases-to-discord.yml
@@ -15,6 +15,9 @@ on:
         description: Release URL to link in Discord
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   github-releases-to-discord:
     runs-on: ubuntu-latest
@@ -23,7 +26,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: GitHub Releases to Discord
-        uses: SethCohen/github-releases-to-discord@v1
+        uses: SethCohen/github-releases-to-discord@24d166886aee4646d448c8a389ff9e1ebcab3682 # v1.20.0
         with:
           webhook_url: ${{ secrets.DISCORD_WEBHOOK_URL_RELEASES }}
           release_name: ${{ inputs.release_name }}

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -8,11 +8,15 @@ on:
   workflow_dispatch:
     inputs:
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   lock:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v6
+      - uses: dessant/lock-threads@89ae32b08ed1a541efecbab17912962a5e38981c # v6.0.2
         with:
           github-token: ${{ github.token }}
           issue-inactive-days: '30'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,9 @@ on:
         default: true
         type: boolean
 
+permissions:
+  contents: read
+
 jobs:
   version:
     runs-on: macos-latest
@@ -48,7 +51,7 @@ jobs:
           fetch-depth: 0
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@main
+        uses: Homebrew/actions/setup-homebrew@b35a29a0f83ee8b8ca07b219fc8db3d7bb88ab49 # 2026.08.10.2
       - name: Install svu
         run: brew install svu
       - name: Compute next version for release
@@ -66,6 +69,12 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     needs: version
+    permissions:
+      # The release commit, the tag push and the JReleaser GitHub release
+      # all use the job token.
+      contents: write
+      # JReleaser pushes the Docker images to ghcr with the job token.
+      packages: write
     steps:
       - name: Remove unnecessary files
         run: |
@@ -85,19 +94,19 @@ jobs:
         run: sed -i -e "s/version=.*/version=${{ needs.version.outputs.version_next }}/" gradle.properties
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -131,7 +140,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6.3.0
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
 
       - name: Build
         run: ./gradlew :komga:webuiCopyIndex :komga:nextuiCopyIndex :komga:bootJar :komga-tray:jar
@@ -163,7 +172,7 @@ jobs:
             build/jreleaser/output.properties
 
       - name: Release commit and push
-        uses: EndBug/add-and-commit@v10
+        uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10.0.0
         if: needs.version.outputs.should_release #only redo if the version changed
         with:
           message: 'chore(release): ${{ needs.version.outputs.version_next }} [skip ci]'
@@ -179,7 +188,7 @@ jobs:
           echo $APPLE_PRIVATE_KEY | base64 --decode > ./secret/apple_private_key.p8
 
       - name: Conveyor make copied-site
-        uses: hydraulic-software/conveyor/actions/build@v22.1
+        uses: hydraulic-software/conveyor/actions/build@5011cc412f9c3a67d8f72f9ea5db5f34c4a68e36 # v22.1
         if: inputs.conveyor-copied-site
         with:
           command: --cache-limit=2.0 -f conveyor.ci.conf make copied-site -o ./output/site
@@ -232,7 +241,7 @@ jobs:
             build/jreleaser/output.properties
 
       - name: Conveyor - publish to Microsoft Store
-        uses: hydraulic-software/conveyor/actions/build@v22.1
+        uses: hydraulic-software/conveyor/actions/build@5011cc412f9c3a67d8f72f9ea5db5f34c4a68e36 # v22.1
         if: inputs.msstore_release
         with:
           command: --cache-limit=2.0 -f conveyor.msstore.ci.conf make ms-store-release -o ./output/msstore
@@ -256,9 +265,11 @@ jobs:
   dispatch:
     needs: release
     runs-on: ubuntu-latest
+    # The dispatch call authenticates with a PAT, the job token is not used.
+    permissions: {}
     steps:
       - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v4
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           repository: gotson/komga-website

--- a/.github/workflows/test-komga.yml
+++ b/.github/workflows/test-komga.yml
@@ -24,9 +24,16 @@ on:
       - 'dependabot/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      # The JUnit report step publishes a check run.
+      checks: write
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
@@ -42,7 +49,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6.3.0
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
 
       - name: Build
         run: ./gradlew build :komga-tray:jar
@@ -62,7 +69,7 @@ jobs:
           path: komga/build/reports/tests/
 
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v6
+        uses: mikepenz/action-junit-report@d9f48fc87bc235f7e214acf696ca5abc0a986f16 # v6.4.2
         if: always()
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'
@@ -70,7 +77,7 @@ jobs:
 
       - name: Conveyor - compute JDK module list
         if: github.event_name == 'push' && github.repository_owner == 'gotson' && contains(matrix.os, 'ubuntu')
-        uses: hydraulic-software/conveyor/actions/build@v22.1
+        uses: hydraulic-software/conveyor/actions/build@5011cc412f9c3a67d8f72f9ea5db5f34c4a68e36 # v22.1
         with:
           command: -f conveyor.detect.conf -Kapp.machines=mac.aarch64 make processed-jars
           signing_key: ${{ secrets.CONVEYOR_SIGNING_KEY }}

--- a/.github/workflows/test-nextui.yml
+++ b/.github/workflows/test-nextui.yml
@@ -14,6 +14,9 @@ on:
       - 'dependabot/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test-unit:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-webui.yml
+++ b/.github/workflows/test-webui.yml
@@ -14,6 +14,9 @@ on:
       - 'dependabot/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   webui:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Every third party action ref in the workflows and the two composite actions now points to a full commit SHA, and every workflow declares the token permissions its steps actually use. First party actions (actions/*) stay on their tags, the trust question is different for actions GitHub maintains itself. If you ever chase a perfect OpenSSF Scorecard, its pinned-dependencies check wants those pinned too, easy to add on top of this.

**Why pins.** A tag like `v22.1` or a branch like `main` is a movable pointer: whoever controls the action repository can move it, and the next run executes their code with this repo's secrets. The release job here holds the Docker Hub and ghcr credentials, the Conveyor signing key, the Apple notary keys, the MS Store client secrets and the Backblaze keys, which makes it exactly the kind of target the tj-actions/changed-files incident (CVE-2025-30066) hit in March 2025: a popular action's tags were force-moved to malicious commits and every repo referencing a tag ran them. A 40-character SHA cannot be moved.

Each pin carries a version comment with the tag it was resolved from, so the refs stay readable and any of them can be cross-checked: the SHA is the commit the named tag points to. Zero behavior change anywhere: every SHA is the exact version already in use. Two refs needed a judgment call, called out for review:

- `chromaui/action@latest` resolves today to v18.1.0, so that is the pin. It stops silently tracking their releases, which is the point.
- `Homebrew/actions/setup-homebrew@main` was pinned to their 2026.08.10.2 tag, which is where main points today.

**Permissions.** Without a `permissions:` block the job token inherits the repository default scope. Each workflow now declares what it uses: the test and utility workflows get read-only tokens, the JUnit reporter keeps `checks: write`, the two repository-dispatch jobs drop the token entirely since they authenticate with your PAT, and the release job keeps `contents: write` and `packages: write` for the version commit, the GitHub release and the ghcr push. The browserslist workflow already declared its scopes and was left untouched.

Maintenance stays as it is today: your weekly dependabot `github-actions` config updates SHA pins the same way it bumps tags, like the recent deps(ci) bump of actions/checkout from 6 to 7, and each update PR shows the new version in the pin comment.

One heads-up: if the repository ever restricts allowed actions using tag patterns (`owner/action@v1`), those entries stop matching SHA refs and workflows fail at startup. The fix is `owner/action@*` in the allowed-actions settings.

Found and fixed by [Plumber](https://github.com/getplumber/plumber)'s analysis, reviewed and submitted by me.