### PR TITLE
fix(webreader): reset reader when changing books

### DIFF
--- a/komga-webui/src/views/DivinaReader.vue
+++ b/komga-webui/src/views/DivinaReader.vue
@@ -121,7 +121,7 @@
       </v-slide-y-reverse-transition>
     </div>
 
-    <div class="full-height">
+    <div class="full-height" :key="bookId">
       <continuous-reader
         v-if="continuousReader"
         :pages="pages"


### PR DESCRIPTION
Fixes #2304. When navigating between books, DivinaReader updates the pages prop while reusing the paged or continuous reader component. Those components retain internal state, which can briefly display pages from the previous book. Key the reader container by bookId so Vue remounts the reader whenever the book changes. This resets stale page, scroll, intersection, and carousel state for both paged and webtoon reading modes, following the existing EpubReader pattern. Validation: npm run lint; npm run test:unit -- --runInBand (14 tests passed). The production build was attempted under Node 20 but stalls during the existing Vuetify/Sass compilation phase, emitting only dependency deprecation warnings.