### PR TITLE
fix(kobo): allow proxy requests without raw sync token

### DIFF
--- a/komga/src/main/kotlin/org/gotson/komga/infrastructure/kobo/KoboProxy.kt
+++ b/komga/src/main/kotlin/org/gotson/komga/infrastructure/kobo/KoboProxy.kt
@@ -108,8 +108,6 @@ class KoboProxy(
           if (includeSyncToken) {
             if (syncToken != null && syncToken.rawKoboSyncToken.isNotBlank()) {
               headersOut.add(X_KOBO_SYNCTOKEN, syncToken.rawKoboSyncToken)
-            } else {
-              throw IllegalStateException("request must include sync token, but no raw Kobo sync token found")
             }
           }
           logger.debug { "Headers out: $headersOut" }


### PR DESCRIPTION
Kobo Sync hasn't been working properly, any connection sync related to the Kobo servers didn't work since the Kobo device couldn't establish a sync-token (The first sync-token will always be empty).

Komga actively refused to let Kobo devices establish the first Sync connection without a token, making Sync towards Kobo servers impossible.

This removes the "must have a sync token" limit, making it possible to sync Kobo books to Kobo Devices configured to reach out to Komga Server.


I have no idea why this check was in place.