### PR TITLE
Rank read list import matches using the years from the CBL

### DIFF
--- a/komga/src/main/kotlin/org/gotson/komga/domain/model/ReadListRequest.kt
+++ b/komga/src/main/kotlin/org/gotson/komga/domain/model/ReadListRequest.kt
@@ -17,6 +17,10 @@ data class ReadListRequestBook(
    * The year the series started, if known. Used to discriminate between series sharing the same title.
    */
   val seriesYear: Int? = null,
+  /**
+   * The year the requested issue was released, if known. Used to discriminate between books sharing the same number.
+   */
+  val issueYear: Int? = null,
 )
 
 data class ReadListRequestMatch(
@@ -45,4 +49,5 @@ data class ReadListRequestBookMatchBook(
   val id: String,
   val number: String,
   val title: String,
+  val releaseDate: LocalDate? = null,
 )

--- a/komga/src/main/kotlin/org/gotson/komga/domain/model/ReadListRequest.kt
+++ b/komga/src/main/kotlin/org/gotson/komga/domain/model/ReadListRequest.kt
@@ -13,6 +13,10 @@ data class ReadListRequest(
 data class ReadListRequestBook(
   val series: Set<String>,
   val number: String,
+  /**
+   * The year the series started, if known. Used to discriminate between series sharing the same title.
+   */
+  val seriesYear: Int? = null,
 )
 
 data class ReadListRequestMatch(

--- a/komga/src/main/kotlin/org/gotson/komga/domain/service/ReadListMatcher.kt
+++ b/komga/src/main/kotlin/org/gotson/komga/domain/service/ReadListMatcher.kt
@@ -3,6 +3,7 @@ package org.gotson.komga.domain.service
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.gotson.komga.domain.model.ReadListMatch
 import org.gotson.komga.domain.model.ReadListRequest
+import org.gotson.komga.domain.model.ReadListRequestBookMatchBook
 import org.gotson.komga.domain.model.ReadListRequestBookMatchSeries
 import org.gotson.komga.domain.model.ReadListRequestBookMatches
 import org.gotson.komga.domain.model.ReadListRequestMatch
@@ -26,35 +27,54 @@ class ReadListMatcher(
       else
         ReadListMatch(request.name)
 
-    val matches = readListRequestRepository.matchBookRequests(request.books).map { it.sortMatchesBySeriesYear() }
+    val matches = readListRequestRepository.matchBookRequests(request.books).map { it.sortMatchesByYear() }
 
     return ReadListRequestMatch(readListMatch, matches)
   }
 
   /**
-   * Sorts the matched series by how well they corroborate the requested series year, best match first.
+   * Sorts the matched series, and the books within them, by how well they corroborate the years of the request.
    *
    * A request matches every series with that exact title, but also the ones where the volume was
    * appended to the title, like `Batman (2016)`. Clients select the first match by default, so the
    * most likely candidate has to come first.
+   *
+   * Nothing is ever discarded, and matches are left in the order the repository returned them whenever the
+   * request carries no year, or no match can be corroborated by one.
    */
-  private fun ReadListRequestBookMatches.sortMatchesBySeriesYear(): ReadListRequestBookMatches {
-    val year = request.seriesYear
-    if (year == null || matches.size < 2) return this
+  private fun ReadListRequestBookMatches.sortMatchesByYear(): ReadListRequestBookMatches {
+    val seriesYear = request.seriesYear
+    val issueYear = request.issueYear
+    if (seriesYear == null && issueYear == null) return this
+
+    val matchesWithSortedBooks =
+      matches.mapValues { (_, books) ->
+        if (books.size < 2) books else books.sortedByDescending { if (it.matchesIssueYear(issueYear)) 1 else 0 }
+      }
+    if (matchesWithSortedBooks.size < 2) return copy(matches = matchesWithSortedBooks)
 
     return copy(
       matches =
-        matches.entries
-          .sortedByDescending { (series, _) -> series.seriesYearScore(year) }
+        matchesWithSortedBooks.entries
+          .sortedByDescending { (series, books) -> series.yearScore(seriesYear) + books.issueYearScore(issueYear) }
           .associate { (series, books) -> series to books },
-    ).also { sorted -> logger.debug { "Sorted matches for $request by series year $year: ${sorted.matches.keys.map { it.title }}" } }
+    ).also { sorted -> logger.debug { "Sorted matches for $request: ${sorted.matches.keys.map { it.title }}" } }
   }
 
   /**
    * Scores how much a matched series corroborates [year]. A volume appended to the title is an explicit
    * signal, and ranks higher than the release date of the first book of the series.
    */
-  private fun ReadListRequestBookMatchSeries.seriesYearScore(year: Int): Int =
-    (if (title.trimEnd().endsWith(" ($year)")) 2 else 0) +
+  private fun ReadListRequestBookMatchSeries.yearScore(year: Int?): Int {
+    if (year == null) return 0
+    return (if (title.trimEnd().endsWith(" ($year)")) 2 else 0) +
       (if (releaseDate?.year == year) 1 else 0)
+  }
+
+  /**
+   * Scores whether a series holds a matched book released in [year], which corroborates the series itself.
+   */
+  private fun Collection<ReadListRequestBookMatchBook>.issueYearScore(year: Int?): Int = if (any { it.matchesIssueYear(year) }) 1 else 0
+
+  private fun ReadListRequestBookMatchBook.matchesIssueYear(year: Int?): Boolean = year != null && releaseDate?.year == year
 }

--- a/komga/src/main/kotlin/org/gotson/komga/domain/service/ReadListMatcher.kt
+++ b/komga/src/main/kotlin/org/gotson/komga/domain/service/ReadListMatcher.kt
@@ -3,6 +3,8 @@ package org.gotson.komga.domain.service
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.gotson.komga.domain.model.ReadListMatch
 import org.gotson.komga.domain.model.ReadListRequest
+import org.gotson.komga.domain.model.ReadListRequestBookMatchSeries
+import org.gotson.komga.domain.model.ReadListRequestBookMatches
 import org.gotson.komga.domain.model.ReadListRequestMatch
 import org.gotson.komga.domain.persistence.ReadListRepository
 import org.gotson.komga.domain.persistence.ReadListRequestRepository
@@ -24,8 +26,35 @@ class ReadListMatcher(
       else
         ReadListMatch(request.name)
 
-    val matches = readListRequestRepository.matchBookRequests(request.books)
+    val matches = readListRequestRepository.matchBookRequests(request.books).map { it.sortMatchesBySeriesYear() }
 
     return ReadListRequestMatch(readListMatch, matches)
   }
+
+  /**
+   * Sorts the matched series by how well they corroborate the requested series year, best match first.
+   *
+   * A request matches every series with that exact title, but also the ones where the volume was
+   * appended to the title, like `Batman (2016)`. Clients select the first match by default, so the
+   * most likely candidate has to come first.
+   */
+  private fun ReadListRequestBookMatches.sortMatchesBySeriesYear(): ReadListRequestBookMatches {
+    val year = request.seriesYear
+    if (year == null || matches.size < 2) return this
+
+    return copy(
+      matches =
+        matches.entries
+          .sortedByDescending { (series, _) -> series.seriesYearScore(year) }
+          .associate { (series, books) -> series to books },
+    ).also { sorted -> logger.debug { "Sorted matches for $request by series year $year: ${sorted.matches.keys.map { it.title }}" } }
+  }
+
+  /**
+   * Scores how much a matched series corroborates [year]. A volume appended to the title is an explicit
+   * signal, and ranks higher than the release date of the first book of the series.
+   */
+  private fun ReadListRequestBookMatchSeries.seriesYearScore(year: Int): Int =
+    (if (title.trimEnd().endsWith(" ($year)")) 2 else 0) +
+      (if (releaseDate?.year == year) 1 else 0)
 }

--- a/komga/src/main/kotlin/org/gotson/komga/infrastructure/jooq/main/ReadListRequestDao.kt
+++ b/komga/src/main/kotlin/org/gotson/komga/infrastructure/jooq/main/ReadListRequestDao.kt
@@ -45,6 +45,7 @@ class ReadListRequestDao(
           bd.NUMBER,
           bd.TITLE,
           bma.RELEASE_DATE,
+          bd.RELEASE_DATE,
         ).from(requestsTable)
         .innerJoin(sd)
         .on(requestsTable.field(seriesField, String::class.java)?.eq(sd.TITLE.noCase()))
@@ -62,7 +63,7 @@ class ReadListRequestDao(
           // use the requests index to match results
           records.groupBy(
             { ReadListRequestBookMatchSeries(it.get(1, String::class.java), it.get(2, String::class.java), it.get(6, LocalDate::class.java)) },
-            { ReadListRequestBookMatchBook(it.get(3, String::class.java), it.get(4, String::class.java), it.get(5, String::class.java)) },
+            { ReadListRequestBookMatchBook(it.get(3, String::class.java), it.get(4, String::class.java), it.get(5, String::class.java), it.get(7, LocalDate::class.java)) },
           )
         }
 

--- a/komga/src/main/kotlin/org/gotson/komga/infrastructure/metadata/comicrack/ReadListProvider.kt
+++ b/komga/src/main/kotlin/org/gotson/komga/infrastructure/metadata/comicrack/ReadListProvider.kt
@@ -8,6 +8,7 @@ import org.gotson.komga.domain.model.ReadListRequestBook
 import org.gotson.komga.infrastructure.metadata.comicrack.dto.ReadingList
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
+import java.time.LocalDate
 
 private val logger = KotlinLogging.logger {}
 
@@ -33,10 +34,16 @@ class ReadListProvider(
       readingList.books.map {
         if (it.series.isNullOrBlank() || it.number == null) throw ComicRackListException("Book is missing series or number: $it", "ERR_1031")
         val series = setOfNotNull(computeSeriesFromSeriesAndVolume(it.series, it.volume), it.series?.ifBlank { null })
-        ReadListRequestBook(series, it.number!!.trim())
+        ReadListRequestBook(series, it.number!!.trim(), it.volume?.takeIf { volume -> volume.isPlausibleSeriesYear() })
       }
 
     return ReadListRequest(name = readingList.name!!, books = books)
       .also { logger.debug { "Converted request: $it" } }
   }
 }
+
+/**
+ * In the ComicRack reading list format the `Volume` element holds the year the series started.
+ * Some tools write a volume ordinal instead, which cannot be used as a year.
+ */
+private fun Int.isPlausibleSeriesYear() = this in 1900..LocalDate.now().year + 1

--- a/komga/src/main/kotlin/org/gotson/komga/infrastructure/metadata/comicrack/ReadListProvider.kt
+++ b/komga/src/main/kotlin/org/gotson/komga/infrastructure/metadata/comicrack/ReadListProvider.kt
@@ -34,7 +34,12 @@ class ReadListProvider(
       readingList.books.map {
         if (it.series.isNullOrBlank() || it.number == null) throw ComicRackListException("Book is missing series or number: $it", "ERR_1031")
         val series = setOfNotNull(computeSeriesFromSeriesAndVolume(it.series, it.volume), it.series?.ifBlank { null })
-        ReadListRequestBook(series, it.number!!.trim(), it.volume?.takeIf { volume -> volume.isPlausibleSeriesYear() })
+        ReadListRequestBook(
+          series = series,
+          number = it.number!!.trim(),
+          seriesYear = it.volume?.takeIf { volume -> volume.isPlausibleYear() },
+          issueYear = it.year?.takeIf { year -> year.isPlausibleYear() },
+        )
       }
 
     return ReadListRequest(name = readingList.name!!, books = books)
@@ -43,7 +48,7 @@ class ReadListProvider(
 }
 
 /**
- * In the ComicRack reading list format the `Volume` element holds the year the series started.
- * Some tools write a volume ordinal instead, which cannot be used as a year.
+ * In the ComicRack reading list format the `Volume` element holds the year the series started, and the `Year`
+ * element the year the issue was released. Some tools write a volume ordinal instead, which cannot be used as a year.
  */
-private fun Int.isPlausibleSeriesYear() = this in 1900..LocalDate.now().year + 1
+private fun Int.isPlausibleYear() = this in 1900..LocalDate.now().year + 1

--- a/komga/src/main/kotlin/org/gotson/komga/interfaces/api/rest/dto/ReadListRequestMatchDto.kt
+++ b/komga/src/main/kotlin/org/gotson/komga/interfaces/api/rest/dto/ReadListRequestMatchDto.kt
@@ -19,7 +19,7 @@ fun ReadListRequestMatch.toDto() =
       ReadListRequestBookMatchesDto(
         request.request.toDto(),
         request.matches.entries.map { (series, books) ->
-          ReadListRequestBookMatchDto(ReadListRequestBookMatchSeriesDto(series.id, series.title, series.releaseDate), books.map { ReadListRequestBookMatchBookDto(it.id, it.number, it.title) })
+          ReadListRequestBookMatchDto(ReadListRequestBookMatchSeriesDto(series.id, series.title, series.releaseDate), books.map { ReadListRequestBookMatchBookDto(it.id, it.number, it.title, it.releaseDate) })
         },
       )
     },
@@ -64,4 +64,6 @@ data class ReadListRequestBookMatchBookDto(
   val bookId: String,
   val number: String,
   val title: String,
+  @JsonFormat(pattern = "yyyy-MM-dd")
+  val releaseDate: LocalDate?,
 )

--- a/komga/src/test/kotlin/org/gotson/komga/domain/service/ReadListMatcherTest.kt
+++ b/komga/src/test/kotlin/org/gotson/komga/domain/service/ReadListMatcherTest.kt
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import java.time.LocalDate
 
 @SpringBootTest
 class ReadListMatcherTest(
@@ -37,6 +38,7 @@ class ReadListMatcherTest(
   @Autowired private val readListRepository: ReadListRepository,
   @Autowired private val libraryRepository: LibraryRepository,
   @Autowired private val bookMetadataRepository: BookMetadataRepository,
+  @Autowired private val seriesMetadataLifecycle: SeriesMetadataLifecycle,
   @Autowired private val readListMatcher: ReadListMatcher,
 ) {
   private val library = makeLibrary()
@@ -280,6 +282,127 @@ class ReadListMatcherTest(
           ),
         )
       }
+    }
+
+    /**
+     * Creates a series with a single book, and aggregates its metadata so the release date is available for matching.
+     */
+    private fun makeSeriesWithFirstIssue(
+      name: String,
+      title: String,
+      releaseDate: LocalDate,
+    ) = makeSeries(name = name, libraryId = library.id).also { s ->
+      val books = listOf(makeBook("book1", libraryId = library.id))
+      seriesLifecycle.createSeries(s)
+      seriesLifecycle.addBooks(s, books)
+      seriesLifecycle.sortBooks(s)
+      seriesMetadataRepository.findById(s.id).let {
+        seriesMetadataRepository.update(it.copy(title = title))
+      }
+      bookMetadataRepository.findById(books[0].id).let {
+        bookMetadataRepository.update(it.copy(number = "1", releaseDate = releaseDate))
+      }
+      seriesMetadataLifecycle.aggregateMetadata(s)
+    }
+
+    @Test
+    fun `given series with volume in title when matching with a series year then the matching volume comes first`() {
+      // given
+      val seriesOriginal = makeSeriesWithFirstIssue("batman-1940", "Batman", LocalDate.of(1940, 4, 25))
+      val seriesRebirth = makeSeriesWithFirstIssue("batman-2016", "Batman (2016)", LocalDate.of(2016, 8, 3))
+
+      val request =
+        ReadListRequest(
+          name = "readlist",
+          books = listOf(ReadListRequestBook(series = setOf("Batman (2016)", "Batman"), number = "1", seriesYear = 2016)),
+        )
+
+      // when
+      val result = readListMatcher.matchReadListRequest(request)
+
+      // then
+      assertThat(result.requests).hasSize(1)
+      val matchedSeriesIds =
+        result.requests
+          .first()
+          .matches.keys
+          .map { it.id }
+      assertThat(matchedSeriesIds).containsExactly(seriesRebirth.id, seriesOriginal.id)
+    }
+
+    @Test
+    fun `given series sharing the same title when matching with a series year then the matching first issue comes first`() {
+      // given
+      val seriesOriginal = makeSeriesWithFirstIssue("batman-1940", "Batman", LocalDate.of(1940, 4, 25))
+      val seriesRebirth = makeSeriesWithFirstIssue("batman-2016", "Batman", LocalDate.of(2016, 8, 3))
+
+      val request =
+        ReadListRequest(
+          name = "readlist",
+          books = listOf(ReadListRequestBook(series = setOf("Batman (2016)", "Batman"), number = "1", seriesYear = 2016)),
+        )
+
+      // when
+      val result = readListMatcher.matchReadListRequest(request)
+
+      // then
+      assertThat(result.requests).hasSize(1)
+      val matchedSeriesIds =
+        result.requests
+          .first()
+          .matches.keys
+          .map { it.id }
+      assertThat(matchedSeriesIds).containsExactly(seriesRebirth.id, seriesOriginal.id)
+    }
+
+    @Test
+    fun `given series sharing the same title when matching with an older series year then the matching first issue comes first`() {
+      // given
+      val seriesOriginal = makeSeriesWithFirstIssue("batman-1940", "Batman", LocalDate.of(1940, 4, 25))
+      val seriesRebirth = makeSeriesWithFirstIssue("batman-2016", "Batman", LocalDate.of(2016, 8, 3))
+
+      val request =
+        ReadListRequest(
+          name = "readlist",
+          books = listOf(ReadListRequestBook(series = setOf("Batman (1940)", "Batman"), number = "1", seriesYear = 1940)),
+        )
+
+      // when
+      val result = readListMatcher.matchReadListRequest(request)
+
+      // then
+      assertThat(result.requests).hasSize(1)
+      val matchedSeriesIds =
+        result.requests
+          .first()
+          .matches.keys
+          .map { it.id }
+      assertThat(matchedSeriesIds).containsExactly(seriesOriginal.id, seriesRebirth.id)
+    }
+
+    @Test
+    fun `given series sharing a title when matching without a series year then all matches are kept`() {
+      // given
+      val seriesOriginal = makeSeriesWithFirstIssue("batman-1940", "Batman", LocalDate.of(1940, 4, 25))
+      val seriesRebirth = makeSeriesWithFirstIssue("batman-2016", "Batman (2016)", LocalDate.of(2016, 8, 3))
+
+      val request =
+        ReadListRequest(
+          name = "readlist",
+          books = listOf(ReadListRequestBook(series = setOf("Batman (2016)", "Batman"), number = "1")),
+        )
+
+      // when
+      val result = readListMatcher.matchReadListRequest(request)
+
+      // then
+      assertThat(result.requests).hasSize(1)
+      val matchedSeriesIds =
+        result.requests
+          .first()
+          .matches.keys
+          .map { it.id }
+      assertThat(matchedSeriesIds).containsExactlyInAnyOrder(seriesOriginal.id, seriesRebirth.id)
     }
   }
 }

--- a/komga/src/test/kotlin/org/gotson/komga/domain/service/ReadListMatcherTest.kt
+++ b/komga/src/test/kotlin/org/gotson/komga/domain/service/ReadListMatcherTest.kt
@@ -404,5 +404,99 @@ class ReadListMatcherTest(
           .map { it.id }
       assertThat(matchedSeriesIds).containsExactlyInAnyOrder(seriesOriginal.id, seriesRebirth.id)
     }
+
+    @Test
+    fun `given series sharing the same title and no series year when matching with an issue year then the matching release date comes first`() {
+      // given
+      val seriesOriginal = makeSeriesWithFirstIssue("batman-1940", "Batman", LocalDate.of(1940, 4, 25))
+      val seriesRebirth = makeSeriesWithFirstIssue("batman-2016", "Batman", LocalDate.of(2016, 8, 3))
+
+      val request =
+        ReadListRequest(
+          name = "readlist",
+          books = listOf(ReadListRequestBook(series = setOf("Batman"), number = "1", issueYear = 2016)),
+        )
+
+      // when
+      val result = readListMatcher.matchReadListRequest(request)
+
+      // then
+      assertThat(result.requests).hasSize(1)
+      val matchedSeriesIds =
+        result.requests
+          .first()
+          .matches.keys
+          .map { it.id }
+      assertThat(matchedSeriesIds).containsExactly(seriesRebirth.id, seriesOriginal.id)
+    }
+
+    @Test
+    fun `given series sharing the same title when matching without any year then matches are left untouched`() {
+      // given
+      val seriesOriginal = makeSeriesWithFirstIssue("batman-1940", "Batman", LocalDate.of(1940, 4, 25))
+      val seriesRebirth = makeSeriesWithFirstIssue("batman-2016", "Batman", LocalDate.of(2016, 8, 3))
+
+      val request =
+        ReadListRequest(
+          name = "readlist",
+          books = listOf(ReadListRequestBook(series = setOf("Batman"), number = "1")),
+        )
+
+      // when
+      val result = readListMatcher.matchReadListRequest(request)
+
+      // then
+      assertThat(result.requests).hasSize(1)
+      val matchedSeriesIds =
+        result.requests
+          .first()
+          .matches.keys
+          .map { it.id }
+      assertThat(matchedSeriesIds).containsExactlyInAnyOrder(seriesOriginal.id, seriesRebirth.id)
+    }
+
+    @Test
+    fun `given books sharing the same number when matching with an issue year then the matching book comes first`() {
+      // given
+      val books =
+        listOf(
+          makeBook("book1", libraryId = library.id),
+          makeBook("book2", libraryId = library.id),
+        )
+      makeSeries(name = "batman", libraryId = library.id).also { s ->
+        seriesLifecycle.createSeries(s)
+        seriesLifecycle.addBooks(s, books)
+        seriesLifecycle.sortBooks(s)
+        seriesMetadataRepository.findById(s.id).let {
+          seriesMetadataRepository.update(it.copy(title = "Batman"))
+        }
+        bookMetadataRepository.findById(books[0].id).let {
+          bookMetadataRepository.update(it.copy(number = "1", releaseDate = LocalDate.of(1940, 4, 25)))
+        }
+        bookMetadataRepository.findById(books[1].id).let {
+          bookMetadataRepository.update(it.copy(number = "1", releaseDate = LocalDate.of(2016, 8, 3)))
+        }
+        seriesMetadataLifecycle.aggregateMetadata(s)
+      }
+
+      val request =
+        ReadListRequest(
+          name = "readlist",
+          books = listOf(ReadListRequestBook(series = setOf("Batman"), number = "1", issueYear = 2016)),
+        )
+
+      // when
+      val result = readListMatcher.matchReadListRequest(request)
+
+      // then
+      assertThat(result.requests).hasSize(1)
+      val matchedBookIds =
+        result.requests
+          .first()
+          .matches.values
+          .first()
+          .map { it.id }
+      assertThat(matchedBookIds).containsExactly(books[1].id, books[0].id)
+    }
   }
 }

--- a/komga/src/test/kotlin/org/gotson/komga/infrastructure/metadata/comicrack/ReadListProviderTest.kt
+++ b/komga/src/test/kotlin/org/gotson/komga/infrastructure/metadata/comicrack/ReadListProviderTest.kt
@@ -50,11 +50,55 @@ class ReadListProviderTest {
         with(books[0]) {
           assertThat(series).containsExactlyInAnyOrder("series 1 (2005)", "series 1")
           assertThat(number).isEqualTo("4")
+          assertThat(seriesYear).isEqualTo(2005)
         }
 
         with(books[1]) {
           assertThat(series).containsExactlyInAnyOrder("series 2")
           assertThat(number).isEqualTo("1")
+          assertThat(seriesYear).isNull()
+        }
+      }
+    }
+
+    @Test
+    fun `given CBL list with volume ordinals when getting ReadListRequest then series year is not set`() {
+      // given
+      val cbl =
+        ReadingList().apply {
+          name = "my read list"
+          books =
+            listOf(
+              Book().apply {
+                series = "series 1"
+                number = "4"
+                volume = 2
+              },
+              Book().apply {
+                series = "series 2"
+                number = "1"
+                volume = 1
+              },
+            )
+        }
+
+      every { mockMapper.readValue(any<ByteArray>(), ReadingList::class.java) } returns cbl
+
+      // when
+      val request = readListProvider.importFromCbl(ByteArray(0))
+
+      // then
+      with(request) {
+        assertThat(books).hasSize(2)
+
+        with(books[0]) {
+          assertThat(series).containsExactlyInAnyOrder("series 1 (2)", "series 1")
+          assertThat(seriesYear).isNull()
+        }
+
+        with(books[1]) {
+          assertThat(series).containsExactlyInAnyOrder("series 2")
+          assertThat(seriesYear).isNull()
         }
       }
     }

--- a/komga/src/test/kotlin/org/gotson/komga/infrastructure/metadata/comicrack/ReadListProviderTest.kt
+++ b/komga/src/test/kotlin/org/gotson/komga/infrastructure/metadata/comicrack/ReadListProviderTest.kt
@@ -104,6 +104,59 @@ class ReadListProviderTest {
     }
 
     @Test
+    fun `given CBL list with issue years when getting ReadListRequest then issue year is set`() {
+      // given
+      val cbl =
+        ReadingList().apply {
+          name = "my read list"
+          books =
+            listOf(
+              Book().apply {
+                series = "series 1"
+                number = "4"
+                volume = 2005
+                year = 2008
+              },
+              Book().apply {
+                series = "series 2"
+                number = "1"
+                year = 1
+              },
+              Book().apply {
+                series = "series 3"
+                number = "1"
+              },
+            )
+        }
+
+      every { mockMapper.readValue(any<ByteArray>(), ReadingList::class.java) } returns cbl
+
+      // when
+      val request = readListProvider.importFromCbl(ByteArray(0))
+
+      // then
+      with(request) {
+        assertThat(books).hasSize(3)
+
+        with(books[0]) {
+          assertThat(seriesYear).isEqualTo(2005)
+          assertThat(issueYear).isEqualTo(2008)
+        }
+
+        // an implausible year is ignored
+        with(books[1]) {
+          assertThat(seriesYear).isNull()
+          assertThat(issueYear).isNull()
+        }
+
+        with(books[2]) {
+          assertThat(seriesYear).isNull()
+          assertThat(issueYear).isNull()
+        }
+      }
+    }
+
+    @Test
     fun `given CBL list with invalid books when getting ReadListRequest then exception is thrown`() {
       // given
       val cbl =


### PR DESCRIPTION
## Problem

Importing a ComicRack reading list can silently add the wrong book.

`ReadListProvider` builds a candidate set of `{ "Series (Volume)", "Series" }` for each entry, and `ReadListRequestDao` matches every series whose title equals one of them. In a library holding several series that share a name — `Star Wars`, `Star Wars (2015)`, `Star Wars (2020)` — the plain name matches all of them, and they come back in whatever order the database returns them in.

Clients then take the first one:

```ts
// next-ui/src/components/import/readlist/Table.vue
const match = request.matches.find(Boolean)
```

There is no error and no prompt: the row is reported as OK, with a book from the wrong volume.

## Changes

The reading list already carries what is needed to choose correctly, it was just never read.

1. **`fix`** — `Volume` holds the year the series started. Matched series are now sorted by how well they corroborate it: a volume appended to the title is the strongest signal, the release date of the first book of the series (the minimum of `BOOK_METADATA_AGGREGATION.RELEASE_DATE`) comes next.

2. **`feat`** — `Year` holds the year the issue was released. It was already parsed into the DTO but never used. It now orders the books within a series, and a series holding a book released that year ranks higher, which tells apart series sharing a title even when the list carries no usable `Volume`.

## Behaviour when the data is missing

Deliberately conservative, so existing imports do not change shape:

- neither year present: matches are returned exactly as before
- a year present but no match corroborates it: every candidate scores the same, the sort is stable, and the order from the repository survives
- a `Volume` holding an ordinal rather than a year (some tools write `1`, `2`) is ignored
- nothing is ever filtered out, so any series or book can still be picked by hand

## API

The second commit adds `releaseDate` to `ReadListRequestBookMatchBookDto`. It is additive and existing clients are unaffected; no frontend change is included. The first commit carries no API change and stands on its own, if you would rather take only that one.

## Testing

Unit tests in `ReadListProviderTest` (year parsing, rejection of ordinals) and `ReadListMatcherTest` (ranking by volume in the title, by first issue release date, by issue year, ordering of books within a series, and the untouched-when-no-year case).

Also verified on a live instance against a real Marvel Star Wars `.cbl`, a franchise with several identically titled volumes, where every entry matched the correct one.
